### PR TITLE
Add initial Typer CLI skeleton with fixtures

### DIFF
--- a/prt/__init__.py
+++ b/prt/__init__.py
@@ -1,0 +1,3 @@
+"""Personal Relationship Toolkit package."""
+__all__ = ["cli", "config", "db", "google_contacts", "llm"]
+__version__ = "0.1.0"

--- a/prt/cli.py
+++ b/prt/cli.py
@@ -1,0 +1,67 @@
+import typer
+from pathlib import Path
+from typing import Optional
+
+from .config import load_config, save_config, config_path, REQUIRED_FIELDS
+from .db import Database
+from .google_contacts import fetch_contacts
+from .llm import chat
+
+app = typer.Typer(help="Personal Relationship Toolkit")
+
+
+@app.command()
+def run(debug: Optional[bool] = True):
+    """Run the interactive CLI."""
+    cfg = load_config()
+    if not cfg:
+        typer.echo("Config file not found.")
+        typer.echo("See documentation at https://github.com/example/prt")
+        if typer.confirm("Create a new config file?"):
+            cfg = {}
+            cfg["google_api_key"] = typer.prompt("Google API key", default="demo")
+            cfg["openai_api_key"] = typer.prompt("OpenAI API key", default="demo")
+            cfg["db_path"] = typer.prompt("Database path", default="prt.db")
+            save_config(cfg)
+            typer.echo(f"Config saved to {config_path()}")
+        else:
+            raise typer.Exit()
+    missing = [f for f in REQUIRED_FIELDS if f not in cfg]
+    for field in missing:
+        cfg[field] = typer.prompt(f"Enter value for {field}")
+    if missing:
+        save_config(cfg)
+
+    db = Database(Path(cfg["db_path"]))
+    db.connect()
+    db.initialize()
+    typer.echo("Database initialized.")
+    db.backup()
+
+    if db.count_contacts() == 0:
+        typer.echo("No contacts in database.")
+        if typer.confirm("Sync contacts from Google?"):
+            contacts = fetch_contacts(cfg)
+            db.insert_contacts(contacts)
+            typer.echo(f"Inserted {len(contacts)} contacts.")
+    else:
+        typer.echo(f"{db.count_contacts()} contacts in database.")
+
+    if db.count_relationships() == 0:
+        typer.echo("No relationship data found.")
+        if typer.confirm("Add a relationship now?"):
+            contacts = db.list_contacts()
+            for cid, name, email in contacts:
+                typer.echo(f"{cid}: {name} <{email}>")
+            chosen = int(typer.prompt("Select contact id"))
+            tag = typer.prompt("Tag")
+            note = typer.prompt("Note", default="")
+            db.add_relationship(chosen, tag, note)
+            typer.echo("Relationship added.")
+    else:
+        typer.echo(f"{db.count_relationships()} relationships in database.")
+        typer.echo(chat("introduce", cfg))
+
+
+if __name__ == "__main__":
+    app()

--- a/prt/config.py
+++ b/prt/config.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+CONFIG_FILE = 'prt_config.json'
+REQUIRED_FIELDS = ['google_api_key', 'openai_api_key', 'db_path']
+
+
+def config_path() -> Path:
+    """Return path to config file in current working directory."""
+    return Path.cwd() / CONFIG_FILE
+
+
+def load_config() -> Dict[str, Any]:
+    path = config_path()
+    if not path.exists():
+        return {}
+    with path.open('r') as f:
+        return json.load(f)
+
+
+def save_config(cfg: Dict[str, Any]) -> None:
+    with config_path().open('w') as f:
+        json.dump(cfg, f, indent=2)

--- a/prt/db.py
+++ b/prt/db.py
@@ -1,0 +1,56 @@
+import sqlite3
+import shutil
+from pathlib import Path
+from typing import List, Tuple
+
+
+class Database:
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self.conn = None
+
+    def connect(self) -> None:
+        self.conn = sqlite3.connect(self.path)
+
+    def initialize(self) -> None:
+        cur = self.conn.cursor()
+        cur.execute(
+            'CREATE TABLE IF NOT EXISTS contacts (id INTEGER PRIMARY KEY, name TEXT, email TEXT)'
+        )
+        cur.execute(
+            'CREATE TABLE IF NOT EXISTS relationships (id INTEGER PRIMARY KEY, contact_id INTEGER, tag TEXT, note TEXT)'
+        )
+        self.conn.commit()
+
+    def backup(self) -> None:
+        backup_path = self.path.with_suffix('.bak')
+        if self.path.exists():
+            shutil.copy(self.path, backup_path)
+
+    def count_contacts(self) -> int:
+        cur = self.conn.cursor()
+        cur.execute('SELECT COUNT(*) FROM contacts')
+        return cur.fetchone()[0]
+
+    def count_relationships(self) -> int:
+        cur = self.conn.cursor()
+        cur.execute('SELECT COUNT(*) FROM relationships')
+        return cur.fetchone()[0]
+
+    def insert_contacts(self, contacts: List[Tuple[str, str]]):
+        cur = self.conn.cursor()
+        cur.executemany('INSERT INTO contacts(name, email) VALUES (?, ?)', contacts)
+        self.conn.commit()
+
+    def list_contacts(self) -> List[Tuple[int, str, str]]:
+        cur = self.conn.cursor()
+        cur.execute('SELECT id, name, email FROM contacts ORDER BY name')
+        return cur.fetchall()
+
+    def add_relationship(self, contact_id: int, tag: str, note: str):
+        cur = self.conn.cursor()
+        cur.execute(
+            'INSERT INTO relationships(contact_id, tag, note) VALUES (?, ?, ?)',
+            (contact_id, tag, note),
+        )
+        self.conn.commit()

--- a/prt/google_contacts.py
+++ b/prt/google_contacts.py
@@ -1,0 +1,8 @@
+from typing import List, Tuple, Dict
+
+def fetch_contacts(config: Dict[str, str]) -> List[Tuple[str, str]]:
+    """Return sample contacts instead of calling Google."""
+    return [
+        ("Alice Example", "alice@example.com"),
+        ("Bob Example", "bob@example.com"),
+    ]

--- a/prt/llm.py
+++ b/prt/llm.py
@@ -1,0 +1,6 @@
+from typing import Any
+
+
+def chat(message: str, config: Any) -> str:
+    """Return canned LLM response."""
+    return "Hello, I'm your relationship helper."

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # requirements.txt
 typer
-sqlcipher3
 langchain
 google-api-python-client
+pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+from typer.testing import CliRunner
+from prt.cli import app
+
+
+def test_cli_creates_config(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        result = runner.invoke(app, [], input="y\ndemo\ndemo\nprt.db\nn\nn\n")
+        assert result.exit_code == 0
+        assert (Path(td) / "prt_config.json").exists()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,14 @@
+import os
+from prt.config import save_config, load_config
+
+
+def test_config_roundtrip(tmp_path):
+    cfg = {
+        "google_api_key": "g",
+        "openai_api_key": "o",
+        "db_path": str(tmp_path / "db.sqlite"),
+    }
+    os.chdir(tmp_path)
+    save_config(cfg)
+    assert (tmp_path / 'prt_config.json').exists()
+    assert load_config() == cfg


### PR DESCRIPTION
## Summary
- implement `prt` package with CLI, config handling, DB layer, and fixtures
- use Typer for interactive command flow
- provide stub Google contacts and LLM modules
- add basic pytest suite and configure path for tests
- drop sqlcipher3 from requirements and include pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878b6c11a54832f868cb7c83b007415