### PR TITLE
Improve startup checks for config and database

### DIFF
--- a/prt/config.py
+++ b/prt/config.py
@@ -23,8 +23,11 @@ def load_config() -> Dict[str, Any]:
     path = config_path()
     if not path.exists():
         return {}
-    with path.open('r') as f:
-        return json.load(f)
+    try:
+        with path.open('r') as f:
+            return json.load(f)
+    except json.JSONDecodeError as e:
+        raise ValueError("Config file is corrupt") from e
 
 
 def save_config(cfg: Dict[str, Any]) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 from prt.config import save_config, load_config
 
 
@@ -12,3 +13,13 @@ def test_config_roundtrip(tmp_path):
     save_config(cfg)
     assert (tmp_path / 'prt_data' / 'prt_config.json').exists()
     assert load_config() == cfg
+
+
+def test_corrupt_config(tmp_path):
+    os.chdir(tmp_path)
+    cfg_dir = tmp_path / 'prt_data'
+    cfg_dir.mkdir()
+    cfg_path = cfg_dir / 'prt_config.json'
+    cfg_path.write_text('{bad json')
+    with pytest.raises(ValueError):
+        load_config()

--- a/tests/test_setup_database.py
+++ b/tests/test_setup_database.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+from typer.testing import CliRunner
+from setup_database import app
+
+
+def test_corrupt_db_backup(tmp_path):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        data_dir = Path(td) / "prt_data"
+        data_dir.mkdir()
+        db_file = data_dir / "prt.db"
+        db_file.write_text("not a sqlite db")
+
+        result = runner.invoke(app, ["setup"], input="n\n")
+        assert result.exit_code == 0
+        assert not db_file.exists()
+        assert (data_dir / "prt.db.corrupt.bak").exists()


### PR DESCRIPTION
## Summary
- Detect and report corrupt `prt_config.json`
- Validate database file integrity and verify Alembic credentials
- Add unit test for corrupt configuration detection
- Backup corrupted databases during setup and prompt before creating a new one
- Test database setup backup behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ace379fc8832fbd839dcdfe2be315