### PR TITLE
test: add dummy secrets for google contacts

### DIFF
--- a/tests/test_google_contacts.py
+++ b/tests/test_google_contacts.py
@@ -1,9 +1,8 @@
 from pathlib import Path
-from unittest import mock
 
 import pytest
 
-from prt_src.google_contacts import _credentials, _secrets_file
+from prt_src.google_contacts import _credentials
 
 
 class DummyCreds:
@@ -19,13 +18,12 @@ class DummyFlow:
 
 
 def test_credentials_use_client_secret(tmp_path, monkeypatch):
-    secrets_dir = Path(__file__).resolve().parents[1] / 'prt' / 'secrets'
-    secrets_file = secrets_dir / 'client_secret.json'
-    if not secrets_file.exists():
-        pytest.skip('client_secret.json missing')
+    dummy_secret = tmp_path / 'client_secret.json'
+    dummy_secret.write_text('{}')
 
     token_file = tmp_path / 'token.json'
-    monkeypatch.setattr('prt.google_contacts.data_dir', lambda: tmp_path)
+    monkeypatch.setattr('prt_src.google_contacts.data_dir', lambda: tmp_path)
+    monkeypatch.setattr('prt_src.google_contacts._secrets_file', lambda: dummy_secret)
 
     def fake_from_client_secrets_file(path, scopes):
         fake_from_client_secrets_file.called_path = Path(path)
@@ -38,6 +36,6 @@ def test_credentials_use_client_secret(tmp_path, monkeypatch):
 
     creds = _credentials()
 
-    assert fake_from_client_secrets_file.called_path == secrets_file
+    assert fake_from_client_secrets_file.called_path == dummy_secret
     assert token_file.exists()
     assert creds.valid


### PR DESCRIPTION
## Summary
- simulate Google secrets file with temp dummy credentials in tests
- ensure `_credentials` writes token and handles mocked secrets

## Testing
- `pytest -q`
- `pytest tests/test_google_contacts.py::test_credentials_use_client_secret -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73a39a7f8832f9d46a24152cb486d