### PR TITLE
test: add cli command tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,71 +1,90 @@
+"""CLI command tests using Typer's CliRunner."""
+
 from pathlib import Path
+import types
+import sys
 from typer.testing import CliRunner
-from prt_src.cli import app
+
+from prt_src.config import load_config
 
 
-def test_cli_creates_config(tmp_path):
-    """Test that CLI can create a basic configuration."""
+def _get_app(monkeypatch):
+    """Import the CLI app with google contacts stubbed out."""
+    stub = types.ModuleType("prt_src.google_contacts")
+    stub.fetch_contacts = lambda config: []
+    monkeypatch.setitem(sys.modules, "prt_src.google_contacts", stub)
+    monkeypatch.delitem(sys.modules, "prt_src.cli", raising=False)
+    from prt_src.cli import app
+    return app
+
+
+def _mock_prompts(monkeypatch):
+    """Make Prompt/Confirm and typer.confirm return non-interactive defaults."""
+    monkeypatch.setattr("rich.prompt.Prompt.ask", lambda *a, **k: "")
+    monkeypatch.setattr("rich.prompt.Confirm.ask", lambda *a, **k: True)
+    monkeypatch.setattr("typer.confirm", lambda *a, **k: True)
+
+
+def test_setup_creates_config_and_db(monkeypatch, tmp_path):
+    """Running `setup` should create configuration and database files."""
+    _mock_prompts(monkeypatch)
     runner = CliRunner()
-    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
-        # Test with minimal input - just create config and exit
-        result = runner.invoke(app, ["--help"])
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        app = _get_app(monkeypatch)
+        result = runner.invoke(app, ["setup"])
         assert result.exit_code == 0
+        assert "PRT setup completed successfully" in result.stdout
+
+        cfg_file = Path("prt_data/prt_config.json")
+        db_file = Path("prt_data/prt.db")
+        assert cfg_file.exists()
+        assert db_file.exists()
 
 
-def test_cli_database_connection(tmp_path):
-    """Test CLI database connection and initialization."""
+def test_db_status_reports_ok(monkeypatch, tmp_path):
+    """`db-status` should report on the created database."""
+    _mock_prompts(monkeypatch)
     runner = CliRunner()
-    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
-        # Create a minimal config
-        config_dir = Path(td) / "prt_data"
-        config_dir.mkdir()
-        config_file = config_dir / "prt_config.json"
-        config_file.write_text('''{
-            "google_api_key": "demo",
-            "openai_api_key": "demo",
-            "db_path": "prt_data/prt.db",
-            "db_username": "test",
-            "db_password": "test",
-            "db_type": "sqlite",
-            "db_host": "localhost",
-            "db_port": 5432,
-            "db_name": "prt"
-        }''')
-        
-        # Test that CLI can start without errors
-        result = runner.invoke(app, ["--help"])
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        app = _get_app(monkeypatch)
+        runner.invoke(app, ["setup"])
+        result = runner.invoke(app, ["db-status"])
         assert result.exit_code == 0
+        assert "Database status" in result.stdout
+        assert "Database path" in result.stdout
 
 
-def test_cli_with_existing_database(tmp_path):
-    """Test CLI behavior with an existing database."""
+def test_encrypt_db_creates_backup(monkeypatch, tmp_path):
+    """`encrypt-db` should succeed and create a backup of the database."""
+    _mock_prompts(monkeypatch)
     runner = CliRunner()
-    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
-        # Create config and database
-        config_dir = Path(td) / "prt_data"
-        config_dir.mkdir()
-        config_file = config_dir / "prt_config.json"
-        config_file.write_text('''{
-            "google_api_key": "demo",
-            "openai_api_key": "demo",
-            "db_path": "prt_data/prt.db",
-            "db_username": "test",
-            "db_password": "test",
-            "db_type": "sqlite",
-            "db_host": "localhost",
-            "db_port": 5432,
-            "db_name": "prt"
-        }''')
-        
-        # Create a minimal database
-        db_file = config_dir / "prt.db"
-        import sqlite3
-        conn = sqlite3.connect(db_file)
-        conn.execute("CREATE TABLE contacts (id INTEGER PRIMARY KEY, name TEXT, email TEXT)")
-        conn.execute("INSERT INTO contacts (name, email) VALUES ('Test User', 'test@example.com')")
-        conn.commit()
-        conn.close()
-        
-        # Test that CLI can connect to existing database
-        result = runner.invoke(app, ["--help"])
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        app = _get_app(monkeypatch)
+        runner.invoke(app, ["setup"])
+
+        result = runner.invoke(app, ["encrypt-db"])
         assert result.exit_code == 0
+        assert "Database encryption completed successfully" in result.stdout
+
+        backup = Path("prt_data/prt.db.pre_encryption")
+        assert backup.exists()
+        assert load_config().get("db_encrypted") is True
+
+
+def test_decrypt_db_creates_backup(monkeypatch, tmp_path):
+    """`decrypt-db` should succeed and create a pre-decryption backup."""
+    _mock_prompts(monkeypatch)
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        app = _get_app(monkeypatch)
+        runner.invoke(app, ["setup"])
+        runner.invoke(app, ["encrypt-db"])
+
+        result = runner.invoke(app, ["decrypt-db"])
+        assert result.exit_code == 0
+        assert "Database decryption completed successfully" in result.stdout
+
+        backup = Path("prt_data/prt.db.pre_decryption")
+        assert backup.exists()
+        assert load_config().get("db_encrypted") is False
+


### PR DESCRIPTION
## Summary
- add CLI tests for setup, db-status, encrypt-db, and decrypt-db
- mock prompt interactions for non-interactive testing

## Testing
- `pytest tests/test_cli.py -q`
- `pytest -q` *(fails: No module named 'googleapiclient')*


------
https://chatgpt.com/codex/tasks/task_e_68a740b480e0832fabe34d3ddf766eb3