### PR TITLE
fix: remove unused variables flagged by F841

### DIFF
--- a/migrations/setup_database.py
+++ b/migrations/setup_database.py
@@ -9,7 +9,7 @@ by the CLI when needed.
 
 import sys
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Dict, Any
 import typer
 from rich.console import Console
 
@@ -17,8 +17,6 @@ from rich.console import Console
 sys.path.insert(0, str(Path(__file__).parent / "prt_src"))
 
 from prt_src.config import get_db_credentials, data_dir, load_config, save_config
-from prt_src.db import Database
-import shutil
 
 app = typer.Typer(help="PRT Database Setup Utility")
 console = Console()

--- a/prt_src/cli_map.py
+++ b/prt_src/cli_map.py
@@ -215,7 +215,7 @@ class CLIMapper:
             guide_style="magenta"
         )
         
-        menu_desc = menu_branch.add(
+        menu_branch.add(
             Text(f"{menu['description']}", style="cyan italic")
         )
         

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,7 +10,7 @@ from prt_src.api import PRTAPI
 def test_cli_creates_config(tmp_path):
     """Test that CLI can create a basic configuration."""
     runner = CliRunner()
-    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+    with runner.isolated_filesystem(temp_dir=tmp_path):
         # Test with minimal input - just create config and exit
         result = runner.invoke(app, ["--help"])
         assert result.exit_code == 0

--- a/tests/test_make_directory.py
+++ b/tests/test_make_directory.py
@@ -751,7 +751,7 @@ class TestErrorHandling:
         assert generator.validate_export() is True
         
         # Should handle gracefully even with missing fields
-        result = generator.load_export_data()
+        generator.load_export_data()
         # Implementation should handle missing fields gracefully
     
     def test_empty_results(self, tmp_path):

--- a/tests/test_setup_database.py
+++ b/tests/test_setup_database.py
@@ -1,24 +1,10 @@
 from pathlib import Path
-from typer.testing import CliRunner
 from utils.setup_database import setup_database, initialize_database
 
 
 def test_setup_database_functions(tmp_path):
     """Test setup database functions work correctly."""
     # Test setup_database function
-    config = {
-        "google_api_key": "demo",
-        "openai_api_key": "demo",
-        "db_path": str(tmp_path / "prt.db"),
-        "db_username": "test",
-        "db_password": "test",
-        "db_type": "sqlite",
-        "db_host": "localhost",
-        "db_port": 5432,
-        "db_name": "prt"
-    }
-    
-    # Test that setup_database returns config
     result = setup_database(quiet=True)
     assert isinstance(result, dict)
     assert "db_path" in result

--- a/utils/generate_profile_images.py
+++ b/utils/generate_profile_images.py
@@ -52,8 +52,6 @@ def create_initials_image(initials, bg_color, text_color, size=(256, 256)):
     
     # Try to use a default font, fall back to default if not available
     try:
-        # Use a larger font size for 256x256 images
-        font_size = size[0] // 4
         font = ImageFont.load_default()
     except:
         font = ImageFont.load_default()


### PR DESCRIPTION
## Summary
- remove unused `font_size` and other unused variables flagged by F841
- clean up tests and utilities to avoid F841 linter warnings

## Testing
- `ruff check . --select F841`
- `pytest` *(fails: tests/test_cli.py::test_search_export_functionality, tests/test_make_directory.py::TestContactExtraction::test_extract_contacts_from_contacts_search, tests/test_make_directory.py::TestFileGeneration::test_copy_profile_images, tests/test_make_directory.py::TestFileGeneration::test_generate_data_js, tests/test_make_directory.py::TestFullWorkflow::test_full_generation_contacts_with_images)*

------
https://chatgpt.com/codex/tasks/task_e_68b03b79b658832faa4bb948e7cbf225