### PR TITLE
refactor: simplify boolean check in database setup test

### DIFF
--- a/tests/test_setup_database.py
+++ b/tests/test_setup_database.py
@@ -40,7 +40,7 @@ def test_initialize_database(tmp_path):
     
     # Test that initialize_database works
     success = initialize_database(config, quiet=True)
-    assert success == True
+    assert success
     
     # Check that database file was created
     db_file = Path(config["db_path"])


### PR DESCRIPTION
## Summary
- avoid comparing boolean to literal in setup_database test

## Testing
- `ruff check tests/test_setup_database.py --select E712`
- `pytest tests/test_setup_database.py`


------
https://chatgpt.com/codex/tasks/task_e_68b03b7de64c832fb68ac0e46475a5c3