### PR TITLE
fix: remove unnecessary f-strings

### DIFF
--- a/tools/make_directory.py
+++ b/tools/make_directory.py
@@ -835,9 +835,9 @@ class DirectoryGenerator:
         # Success!
         success_text = Text()
         success_text.append("✅ Contact directory generated successfully!\n\n", style="bold green")
-        success_text.append(f"📁 Output: ", style="bold")
+        success_text.append("📁 Output: ", style="bold")
         success_text.append(f"{self.output_path.absolute()}\n", style="blue")
-        success_text.append(f"🌐 Open: ", style="bold")
+        success_text.append("🌐 Open: ", style="bold")
         success_text.append(f"file://{self.output_path.absolute()}/index.html\n", style="blue")
         
         console.print(Panel(success_text, title="Generation Complete", border_style="green"))

--- a/utils/extract_profile_images.py
+++ b/utils/extract_profile_images.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     
     if not db_path.exists():
         print(f"Database not found: {db_path}")
-        print(f"Run 'cd tests && python fixtures.py' to create test database.")
+        print("Run 'cd tests && python fixtures.py' to create test database.")
         sys.exit(1)
     
     print(f"Extracting images from: {db_path}")

--- a/utils/generate_profile_images.py
+++ b/utils/generate_profile_images.py
@@ -166,4 +166,4 @@ if __name__ == "__main__":
     
     # Save to disk for inspection
     save_images_to_disk(profiles)
-    print(f"\nImages saved to 'profile_images/' directory for inspection.")
+    print("\nImages saved to 'profile_images/' directory for inspection.")


### PR DESCRIPTION
## Summary
- remove unnecessary f-strings in tools and utils

## Testing
- `python -m pyflakes tools/make_directory.py utils/extract_profile_images.py utils/generate_profile_images.py`
- `pytest`
- `python tools/make_directory.py --help`
- `python utils/extract_profile_images.py /tmp/nonexistent_db`
- `python utils/generate_profile_images.py`


------
https://chatgpt.com/codex/tasks/task_e_68b03b80e700832fb3f6aa4f70c1adf9