### PR TITLE
Handle bare except blocks in CLI and utils

### DIFF
--- a/prt_src/cli.py
+++ b/prt_src/cli.py
@@ -88,7 +88,8 @@ def check_database_health(api: PRTAPI) -> dict:
             # These might not exist if database is completely empty
             all_contacts = api.list_all_contacts()
             total_contacts = len(all_contacts) if all_contacts else 0
-        except:
+        except Exception as e:
+            console.print(f"Warning: failed to list all contacts: {e}", style="yellow")
             total_contacts = contact_count
         
         return {

--- a/utils/generate_profile_images.py
+++ b/utils/generate_profile_images.py
@@ -55,7 +55,8 @@ def create_initials_image(initials, bg_color, text_color, size=(256, 256)):
         # Use a larger font size for 256x256 images
         font_size = size[0] // 4
         font = ImageFont.load_default()
-    except:
+    except Exception as e:
+        print(f"Failed to load font, using default: {e}")
         font = ImageFont.load_default()
     
     # Get text size and center it


### PR DESCRIPTION
## Summary
- Replace bare `except` in CLI health check with explicit exception handling and warning output
- Add explicit exception handling when loading fonts in profile image generator

## Testing
- `pytest -q` *(fails: pytest reading from stdin; contact extraction tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b03b83af80832fb52802baae106410