### PR TITLE
Configure ruff and black with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.7.3
+    hooks:
+      - id: ruff
+        args: [--fix]
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black

--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@ PRT will automatically detect if setup is needed and guide you through the proce
 python -m prt_src.cli setup
 ```
 
+## Development Workflow
+
+This project uses [pre-commit](https://pre-commit.com/) to run [ruff](https://docs.astral.sh/ruff/) and [black](https://black.readthedocs.io/en/stable/) on staged files.
+
+```bash
+pre-commit install
+pre-commit run --files <file1> <file2>
+```
+
+Run these commands before committing to ensure consistent code style.
+
 ## Motivation/Purpose: 
 
 I am solving a few personal pain points with this project:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,10 @@
+[tool.black]
+line-length = 88
+
+[tool.ruff]
+line-length = 88
+select = ["E", "F", "I"]
+
+[tool.isort]
+profile = "black"
+line_length = 88


### PR DESCRIPTION
## Summary
- add `pyproject.toml` with ruff, black, and isort settings
- configure pre-commit to run ruff and black
- document development workflow in `README`

## Testing
- `pre-commit run --files README.md pyproject.toml .pre-commit-config.yaml`
- `pytest` *(fails: reading from stdin during test_cli and directory generation tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b03b89d074832fbcfd69de6f35fa0a