### PR TITLE
chore: install pre-commit in init script

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -75,6 +75,17 @@ fi
 if [ -n "$VIRTUAL_ENV" ]; then
     echo "Virtual environment activated! You should see (prt_env) in your prompt."
     echo "If you don't see (prt_env), try running: source prt_env/bin/activate"
+
+    # Install development requirements (including pre-commit)
+    if [ -f "requirements-dev.txt" ]; then
+        pip install -v -r requirements-dev.txt || { echo "Failed to install development requirements"; return 1; }
+        pre-commit install || { echo "Failed to install pre-commit hooks"; return 1; }
+
+        # Optionally run pre-commit across the codebase to establish a baseline
+        if [ "${RUN_PRE_COMMIT:-0}" = "1" ]; then
+            pre-commit run --all-files || { echo "pre-commit run failed"; return 1; }
+        fi
+    fi
 else
     echo "Warning: Virtual environment not properly activated"
 fi

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+# Development requirements
+pre-commit


### PR DESCRIPTION
## Summary
- install development requirements and pre-commit via `init.sh`
- add optional `RUN_PRE_COMMIT` to trigger `pre-commit run --all-files`
- track development dependencies in new `requirements-dev.txt`

## Testing
- `pre-commit run --all-files`
- `pytest` *(fails: reading from stdin, contact extraction mismatches)*

------
https://chatgpt.com/codex/tasks/task_e_68b043909f9c832f9f6161d437887bfc