### PR TITLE
chore: update Ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,8 @@ line-length = 88
 
 [tool.ruff]
 line-length = 88
-select = ["E", "F", "I"]
+select = ["E", "F", "I", "W", "UP", "B"]
+ignore = ["E501"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
## Summary
- expand Ruff rule selection to include Flake8 W, Pyupgrade, and Bugbear checks
- ignore E501 so Black can handle line length

## Testing
- `ruff check . | tail -n 20` (fails: Found 1310 errors)
- `pytest -q` (fails: 5 failed, 56 passed, 8 skipped)


------
https://chatgpt.com/codex/tasks/task_e_68b0439fe754832fa081f05f836b97e9