### PR TITLE
chore: remove unused tmp_path fixture

### DIFF
--- a/tests/test_setup_database.py
+++ b/tests/test_setup_database.py
@@ -1,8 +1,9 @@
 from pathlib import Path
-from utils.setup_database import setup_database, initialize_database
+
+from utils.setup_database import initialize_database, setup_database
 
 
-def test_setup_database_functions(tmp_path):
+def test_setup_database_functions():
     """Test setup database functions work correctly."""
     # Test setup_database function
     result = setup_database(quiet=True)
@@ -21,13 +22,13 @@ def test_initialize_database(tmp_path):
         "db_type": "sqlite",
         "db_host": "localhost",
         "db_port": 5432,
-        "db_name": "prt"
+        "db_name": "prt",
     }
-    
+
     # Test that initialize_database works
     success = initialize_database(config, quiet=True)
     assert success
-    
+
     # Check that database file was created
     db_file = Path(config["db_path"])
     assert db_file.exists()


### PR DESCRIPTION
## Summary
- remove unused `tmp_path` fixture from `test_setup_database_functions`

## Testing
- `pre-commit run --files tests/test_setup_database.py`
- `pytest tests/test_setup_database.py -q`
- ⚠️ `pytest -q` (fails: pytest: reading from stdin while output is captured)

------
https://chatgpt.com/codex/tasks/task_e_68b043652190832f82f76836b0766f1c