### PR TITLE
Simplify font loading in profile image generator

### DIFF
--- a/utils/generate_profile_images.py
+++ b/utils/generate_profile_images.py
@@ -50,11 +50,8 @@ def create_initials_image(initials, bg_color, text_color, size=(256, 256)):
     img = Image.new('RGB', size, bg_color)
     draw = ImageDraw.Draw(img)
     
-    # Try to use a default font, fall back to default if not available
-    try:
-        font = ImageFont.load_default()
-    except:
-        font = ImageFont.load_default()
+    # Use default font (always available)
+    font = ImageFont.load_default()
     
     # Get text size and center it
     bbox = draw.textbbox((0, 0), initials, font=font)


### PR DESCRIPTION
## Summary
- Use ImageFont.load_default() directly in create_initials_image to avoid redundant try/except

## Testing
- `pytest -q` *(fails: OSError: pytest: reading from stdin while output is captured; assert errors in make_directory tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b041a59284832f89235d170925ddc3