### PR TITLE
Add safe SQL execution tool and backup awareness

### DIFF
--- a/prt_src/llm_ollama.py
+++ b/prt_src/llm_ollama.py
@@ -6,15 +6,18 @@ with tool calling capabilities for PRT operations.
 """
 
 import json
-import requests
-from typing import Dict, List, Any, Optional, Callable
 from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+import requests
+
 from .api import PRTAPI
 
 
 @dataclass
 class Tool:
     """Represents a tool that can be called by the LLM."""
+
     name: str
     description: str
     parameters: Dict[str, Any]
@@ -23,7 +26,7 @@ class Tool:
 
 class OllamaLLM:
     """Ollama LLM client with tool calling support."""
-    
+
     def __init__(self, api: PRTAPI, base_url: str = "http://localhost:11434/v1"):
         """Initialize Ollama LLM client."""
         self.api = api
@@ -31,7 +34,7 @@ class OllamaLLM:
         self.model = "gpt-oss:20b"
         self.tools = self._create_tools()
         self.conversation_history = []
-    
+
     def _create_tools(self) -> List[Tool]:
         """Create the available tools for the LLM."""
         return [
@@ -41,23 +44,17 @@ class OllamaLLM:
                 parameters={
                     "type": "object",
                     "properties": {
-                        "query": {
-                            "type": "string",
-                            "description": "Search term to find contacts"
-                        }
+                        "query": {"type": "string", "description": "Search term to find contacts"}
                     },
-                    "required": ["query"]
+                    "required": ["query"],
                 },
-                function=self.api.search_contacts
+                function=self.api.search_contacts,
             ),
             Tool(
                 name="list_all_contacts",
                 description="Get a list of all contacts in the database",
-                parameters={
-                    "type": "object",
-                    "properties": {}
-                },
-                function=self.api.list_all_contacts
+                parameters={"type": "object", "properties": {}},
+                function=self.api.list_all_contacts,
             ),
             Tool(
                 name="get_contact_details",
@@ -67,12 +64,12 @@ class OllamaLLM:
                     "properties": {
                         "contact_id": {
                             "type": "integer",
-                            "description": "ID of the contact to get details for"
+                            "description": "ID of the contact to get details for",
                         }
                     },
-                    "required": ["contact_id"]
+                    "required": ["contact_id"],
                 },
-                function=self.api.get_contact_details
+                function=self.api.get_contact_details,
             ),
             Tool(
                 name="search_tags",
@@ -80,23 +77,17 @@ class OllamaLLM:
                 parameters={
                     "type": "object",
                     "properties": {
-                        "query": {
-                            "type": "string",
-                            "description": "Search term to find tags"
-                        }
+                        "query": {"type": "string", "description": "Search term to find tags"}
                     },
-                    "required": ["query"]
+                    "required": ["query"],
                 },
-                function=self.api.search_tags
+                function=self.api.search_tags,
             ),
             Tool(
                 name="list_all_tags",
                 description="Get a list of all tags in the database",
-                parameters={
-                    "type": "object",
-                    "properties": {}
-                },
-                function=self.api.list_all_tags
+                parameters={"type": "object", "properties": {}},
+                function=self.api.list_all_tags,
             ),
             Tool(
                 name="get_contacts_by_tag",
@@ -106,12 +97,12 @@ class OllamaLLM:
                     "properties": {
                         "tag_name": {
                             "type": "string",
-                            "description": "Name of the tag to search for"
+                            "description": "Name of the tag to search for",
                         }
                     },
-                    "required": ["tag_name"]
+                    "required": ["tag_name"],
                 },
-                function=self.api.get_contacts_by_tag
+                function=self.api.get_contacts_by_tag,
             ),
             Tool(
                 name="search_notes",
@@ -119,23 +110,17 @@ class OllamaLLM:
                 parameters={
                     "type": "object",
                     "properties": {
-                        "query": {
-                            "type": "string",
-                            "description": "Search term to find notes"
-                        }
+                        "query": {"type": "string", "description": "Search term to find notes"}
                     },
-                    "required": ["query"]
+                    "required": ["query"],
                 },
-                function=self.api.search_notes
+                function=self.api.search_notes,
             ),
             Tool(
                 name="list_all_notes",
                 description="Get a list of all notes in the database",
-                parameters={
-                    "type": "object",
-                    "properties": {}
-                },
-                function=self.api.list_all_notes
+                parameters={"type": "object", "properties": {}},
+                function=self.api.list_all_notes,
             ),
             Tool(
                 name="get_contacts_by_note",
@@ -145,12 +130,12 @@ class OllamaLLM:
                     "properties": {
                         "note_title": {
                             "type": "string",
-                            "description": "Title of the note to search for"
+                            "description": "Title of the note to search for",
                         }
                     },
-                    "required": ["note_title"]
+                    "required": ["note_title"],
                 },
-                function=self.api.get_contacts_by_note
+                function=self.api.get_contacts_by_note,
             ),
             Tool(
                 name="add_tag_to_contact",
@@ -158,18 +143,12 @@ class OllamaLLM:
                 parameters={
                     "type": "object",
                     "properties": {
-                        "contact_id": {
-                            "type": "integer",
-                            "description": "ID of the contact"
-                        },
-                        "tag_name": {
-                            "type": "string",
-                            "description": "Name of the tag to add"
-                        }
+                        "contact_id": {"type": "integer", "description": "ID of the contact"},
+                        "tag_name": {"type": "string", "description": "Name of the tag to add"},
                     },
-                    "required": ["contact_id", "tag_name"]
+                    "required": ["contact_id", "tag_name"],
                 },
-                function=self.api.add_tag_to_contact
+                function=self.api.add_tag_to_contact,
             ),
             Tool(
                 name="add_note_to_contact",
@@ -177,22 +156,13 @@ class OllamaLLM:
                 parameters={
                     "type": "object",
                     "properties": {
-                        "contact_id": {
-                            "type": "integer",
-                            "description": "ID of the contact"
-                        },
-                        "note_title": {
-                            "type": "string",
-                            "description": "Title of the note"
-                        },
-                        "note_content": {
-                            "type": "string",
-                            "description": "Content of the note"
-                        }
+                        "contact_id": {"type": "integer", "description": "ID of the contact"},
+                        "note_title": {"type": "string", "description": "Title of the note"},
+                        "note_content": {"type": "string", "description": "Content of the note"},
                     },
-                    "required": ["contact_id", "note_title", "note_content"]
+                    "required": ["contact_id", "note_title", "note_content"],
                 },
-                function=self.api.add_note_to_contact
+                function=self.api.add_note_to_contact,
             ),
             Tool(
                 name="create_tag",
@@ -200,14 +170,11 @@ class OllamaLLM:
                 parameters={
                     "type": "object",
                     "properties": {
-                        "name": {
-                            "type": "string",
-                            "description": "Name of the tag to create"
-                        }
+                        "name": {"type": "string", "description": "Name of the tag to create"}
                     },
-                    "required": ["name"]
+                    "required": ["name"],
                 },
-                function=self.api.create_tag
+                function=self.api.create_tag,
             ),
             Tool(
                 name="create_note",
@@ -215,55 +182,77 @@ class OllamaLLM:
                 parameters={
                     "type": "object",
                     "properties": {
-                        "title": {
-                            "type": "string",
-                            "description": "Title of the note"
-                        },
-                        "content": {
-                            "type": "string",
-                            "description": "Content of the note"
-                        }
+                        "title": {"type": "string", "description": "Title of the note"},
+                        "content": {"type": "string", "description": "Content of the note"},
                     },
-                    "required": ["title", "content"]
+                    "required": ["title", "content"],
                 },
-                function=self.api.create_note
+                function=self.api.create_note,
             ),
             Tool(
                 name="get_database_stats",
                 description="Get database statistics including contact and relationship counts",
+                parameters={"type": "object", "properties": {}},
+                function=self.api.get_database_stats,
+            ),
+            Tool(
+                name="create_backup_with_comment",
+                description="Create a manual database backup with an optional comment",
                 parameters={
                     "type": "object",
-                    "properties": {}
+                    "properties": {
+                        "comment": {
+                            "type": "string",
+                            "description": "Optional description for the backup",
+                        }
+                    },
                 },
-                function=self.api.get_database_stats
-            )
+                function=self.api.create_backup_with_comment,
+            ),
+            Tool(
+                name="execute_sql",
+                description="Execute a raw SQL query. Write operations require confirm=true and trigger an automatic backup",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "sql": {
+                            "type": "string",
+                            "description": "SQL to execute",
+                        },
+                        "confirm": {
+                            "type": "boolean",
+                            "description": "Must be true for write operations",
+                        },
+                    },
+                    "required": ["sql"],
+                },
+                function=self.api.execute_sql,
+            ),
         ]
-    
+
     def _get_tool_by_name(self, name: str) -> Optional[Tool]:
         """Get a tool by name."""
         for tool in self.tools:
             if tool.name == name:
                 return tool
         return None
-    
+
     def _call_tool(self, tool_name: str, arguments: Dict[str, Any]) -> Any:
         """Call a tool with the given arguments."""
         tool = self._get_tool_by_name(tool_name)
         if not tool:
             return {"error": f"Tool '{tool_name}' not found"}
-        
+
         try:
             result = tool.function(**arguments)
             return result
         except Exception as e:
             return {"error": f"Error calling tool '{tool_name}': {str(e)}"}
-    
+
     def _create_system_prompt(self) -> str:
         """Create the system prompt for the LLM."""
-        tools_description = "\n".join([
-            f"- {tool.name}: {tool.description}" for tool in self.tools
-        ])
-        
+        tools_description = "\n".join([f"- {tool.name}: {tool.description}" for tool in self.tools])
+
         return f"""You are an AI assistant for the Personal Relationship Toolkit (PRT), a private contact and relationship management system.
 
 Your role is to help users manage their personal contacts, relationships, tags, and notes. You have access to a private database containing the user's contact information.
@@ -278,12 +267,13 @@ AVAILABLE TOOLS:
 {tools_description}
 
 INSTRUCTIONS:
-1. When a user asks about their contacts, relationships, tags, or notes, use the appropriate tools to get real data
-2. Always use tools to perform actions rather than making up information
-3. If a user asks a general question about PRT or how to use it, respond directly without using tools
-4. Be concise but helpful in your responses
-5. If a tool call fails, explain the issue and suggest alternatives
-6. For complex requests, break them down into multiple tool calls if needed
+ 1. When a user asks about their contacts, relationships, tags, or notes, use the appropriate tools to get real data
+ 2. Always use tools to perform actions rather than making up information
+ 3. If a user asks a general question about PRT or how to use it, respond directly without using tools
+ 4. Be concise but helpful in your responses
+ 5. If a tool call fails, explain the issue and suggest alternatives
+ 6. For complex requests, break them down into multiple tool calls if needed
+ 7. Direct SQL queries via execute_sql require caution: write operations need confirm=true and will trigger an automatic backup
 
 EXAMPLES:
 - "Show me all contacts" → Use list_all_contacts tool
@@ -292,128 +282,134 @@ EXAMPLES:
 - "How do I add a tag?" → Respond directly with instructions
 
 Remember: You can only use the tools listed above. You cannot access files, run commands, or modify system configuration."""
-    
+
     def _format_tool_calls(self) -> List[Dict[str, Any]]:
         """Format tools for Ollama API."""
         return [
-            {
-                "name": tool.name,
-                "description": tool.description,
-                "parameters": tool.parameters
-            }
+            {"name": tool.name, "description": tool.description, "parameters": tool.parameters}
             for tool in self.tools
         ]
-    
+
     def chat(self, message: str) -> str:
         """Send a message to the LLM and get a response."""
         # Add user message to conversation history
         self.conversation_history.append({"role": "user", "content": message})
-        
+
         # Prepare the request for Ollama
         request_data = {
             "model": self.model,
-            "messages": [
-                {"role": "system", "content": self._create_system_prompt()}
-            ] + self.conversation_history,
+            "messages": [{"role": "system", "content": self._create_system_prompt()}]
+            + self.conversation_history,
             "tools": self._format_tool_calls(),
-            "stream": False
+            "stream": False,
         }
-        
+
         try:
             # Send request to Ollama with shorter timeout
             response = requests.post(
                 f"{self.base_url}/chat/completions",
                 json=request_data,
-                timeout=30  # Reduced from 120 to 30 seconds
+                timeout=30,  # Reduced from 120 to 30 seconds
             )
             response.raise_for_status()
-            
+
             result = response.json()
-            
+
             # Validate response structure
             if not result.get("choices") or not result["choices"]:
                 return "Error: Invalid response from Ollama - no choices found"
-            
+
             choice = result["choices"][0]
             if not choice.get("message"):
                 return "Error: Invalid response from Ollama - no message found"
-            
+
             message_obj = choice["message"]
-            
+
             # Check if the LLM wants to call a tool
             if "tool_calls" in message_obj and message_obj["tool_calls"]:
                 tool_calls = message_obj["tool_calls"]
                 tool_results = []
-                
+
                 # Limit to prevent infinite loops
                 if len(tool_calls) > 5:
                     return "Error: Too many tool calls requested. Please try a simpler query."
-                
+
                 for tool_call in tool_calls:
                     if not tool_call.get("function"):
                         continue
-                        
+
                     tool_name = tool_call["function"]["name"]
                     arguments_str = tool_call["function"].get("arguments", "{}")
-                    
+
                     # Parse arguments if it's a string
                     try:
-                        arguments = json.loads(arguments_str) if isinstance(arguments_str, str) else arguments_str
+                        arguments = (
+                            json.loads(arguments_str)
+                            if isinstance(arguments_str, str)
+                            else arguments_str
+                        )
                     except json.JSONDecodeError:
                         arguments = {}
-                    
+
                     # Call the tool
                     tool_result = self._call_tool(tool_name, arguments)
-                    tool_results.append({
-                        "tool_call_id": tool_call.get("id", ""),
-                        "name": tool_name,
-                        "result": tool_result
-                    })
-                
+                    tool_results.append(
+                        {
+                            "tool_call_id": tool_call.get("id", ""),
+                            "name": tool_name,
+                            "result": tool_result,
+                        }
+                    )
+
                 # Add assistant message with tool calls to history
                 self.conversation_history.append(message_obj)
-                
+
                 # Add tool results to history
                 for tool_result in tool_results:
-                    self.conversation_history.append({
-                        "role": "tool",
-                        "tool_call_id": tool_result["tool_call_id"],
-                        "content": json.dumps(tool_result["result"])
-                    })
-                
+                    self.conversation_history.append(
+                        {
+                            "role": "tool",
+                            "tool_call_id": tool_result["tool_call_id"],
+                            "content": json.dumps(tool_result["result"]),
+                        }
+                    )
+
                 # Get final response from LLM with shorter timeout
                 final_request = {
                     "model": self.model,
-                    "messages": [
-                        {"role": "system", "content": self._create_system_prompt()}
-                    ] + self.conversation_history,
-                    "stream": False
+                    "messages": [{"role": "system", "content": self._create_system_prompt()}]
+                    + self.conversation_history,
+                    "stream": False,
                 }
-                
+
                 final_response = requests.post(
                     f"{self.base_url}/chat/completions",
                     json=final_request,
-                    timeout=30  # Reduced timeout
+                    timeout=30,  # Reduced timeout
                 )
                 final_response.raise_for_status()
-                
+
                 final_result = final_response.json()
-                
+
                 if not final_result.get("choices") or not final_result["choices"]:
                     return "Error: Invalid final response from Ollama"
-                
+
                 assistant_message = final_result["choices"][0]["message"]["content"]
-                
+
                 # Add final assistant message to history
-                self.conversation_history.append({"role": "assistant", "content": assistant_message})
-                
+                self.conversation_history.append(
+                    {"role": "assistant", "content": assistant_message}
+                )
+
                 return assistant_message
             else:
                 # No tool calls, just return the response
                 assistant_message = message_obj["content"]
-                self.conversation_history.append({"role": "assistant", "content": assistant_message})
+                self.conversation_history.append(
+                    {"role": "assistant", "content": assistant_message}
+                )
                 return assistant_message
-                
+
         except requests.exceptions.Timeout:
             return "Error: Request to Ollama timed out. Please check if Ollama is running and try again."
         except requests.exceptions.ConnectionError:
@@ -422,7 +418,7 @@ Remember: You can only use the tools listed above. You cannot access files, run 
             return f"Error communicating with Ollama: {str(e)}"
         except Exception as e:
             return f"Error processing response: {str(e)}"
-    
+
     def clear_history(self):
         """Clear the conversation history."""
         self.conversation_history = []
@@ -431,7 +427,7 @@ Remember: You can only use the tools listed above. You cannot access files, run 
 def chat_with_ollama(api: PRTAPI, message: str = None) -> str:
     """Convenience function to chat with Ollama LLM."""
     llm = OllamaLLM(api)
-    
+
     if message:
         return llm.chat(message)
     else:
@@ -442,14 +438,16 @@ def start_ollama_chat(api: PRTAPI):
     """Start an interactive chat session with Ollama."""
     from rich.console import Console
     from rich.prompt import Prompt
-    
+
     console = Console()
     llm = OllamaLLM(api)
-    
+
     console.print("🤖 Ollama LLM Chat Mode", style="bold blue")
-    console.print("Type 'quit' to exit, 'clear' to clear history, 'help' for assistance", style="cyan")
+    console.print(
+        "Type 'quit' to exit, 'clear' to clear history, 'help' for assistance", style="cyan"
+    )
     console.print("=" * 50, style="blue")
-    
+
     # Test connection first
     console.print("Testing connection to Ollama...", style="yellow")
     try:
@@ -461,19 +459,19 @@ def start_ollama_chat(api: PRTAPI):
     except Exception as e:
         console.print(f"⚠ Warning: Cannot connect to Ollama: {e}", style="yellow")
         console.print("Make sure Ollama is running with: ollama serve", style="cyan")
-    
+
     while True:
         try:
             user_input = Prompt.ask("\n[bold green]You[/bold green]")
-            
-            if user_input.lower() in ['quit', 'exit', 'q']:
+
+            if user_input.lower() in ["quit", "exit", "q"]:
                 console.print("Goodbye!", style="green")
                 break
-            elif user_input.lower() == 'clear':
+            elif user_input.lower() == "clear":
                 llm.clear_history()
                 console.print("Chat history cleared.", style="yellow")
                 continue
-            elif user_input.lower() == 'help':
+            elif user_input.lower() == "help":
                 console.print("\n[bold blue]Available Commands:[/bold blue]")
                 console.print("- Type your questions about contacts, tags, or notes", style="white")
                 console.print("- 'clear': Clear chat history", style="white")
@@ -486,15 +484,17 @@ def start_ollama_chat(api: PRTAPI):
                 continue
             elif not user_input.strip():
                 continue
-            
+
             console.print("\n[bold blue]Assistant[/bold blue]")
             console.print("Thinking...", style="dim")
             response = llm.chat(user_input)
             console.print(response, style="white")
-            
+
         except (KeyboardInterrupt, EOFError):
             console.print("\nGoodbye!", style="green")
             break
         except Exception as e:
             console.print(f"Error: {e}", style="red")
-            console.print("Try asking a simpler question or type 'help' for assistance.", style="yellow")
+            console.print(
+                "Try asking a simpler question or type 'help' for assistance.", style="yellow"
+            )

--- a/tests/test_execute_sql.py
+++ b/tests/test_execute_sql.py
@@ -1,0 +1,43 @@
+from sqlalchemy import text
+
+from prt_src.api import PRTAPI
+
+
+def _make_api(test_db):
+    db, _ = test_db
+    config = {"db_path": str(db.path), "db_encrypted": False}
+    return PRTAPI(config)
+
+
+def test_execute_sql_read_only_returns_rows(test_db):
+    api = _make_api(test_db)
+    result = api.execute_sql("SELECT name FROM contacts ORDER BY id LIMIT 1")
+    assert result["error"] is None
+    assert isinstance(result["rows"], list)
+    assert result["rowcount"] == 1
+
+
+def test_execute_sql_write_requires_confirmation(test_db):
+    api = _make_api(test_db)
+    initial = api.db.session.execute(text("SELECT COUNT(*) FROM contacts")).scalar()
+    result = api.execute_sql("DELETE FROM contacts WHERE id=1")
+    assert result["error"] is not None
+    assert "confirm" in result["error"].lower()
+    count = api.db.session.execute(text("SELECT COUNT(*) FROM contacts")).scalar()
+    assert count == initial
+
+
+def test_execute_sql_backup_before_write(test_db, monkeypatch):
+    api = _make_api(test_db)
+    called = {}
+
+    def fake_backup(op):
+        called["op"] = op
+        return {}
+
+    monkeypatch.setattr(api, "auto_backup_before_operation", fake_backup)
+    result = api.execute_sql("UPDATE contacts SET name='Changed' WHERE id=1", confirm=True)
+    assert called
+    assert result["rowcount"] == 1
+    name = api.db.session.execute(text("SELECT name FROM contacts WHERE id=1")).scalar()
+    assert name == "Changed"

--- a/tests/test_ollama_integration.py
+++ b/tests/test_ollama_integration.py
@@ -2,22 +2,22 @@
 Tests for Ollama LLM integration.
 """
 
-import pytest
 from unittest.mock import Mock, patch
+
 from prt_src.llm_ollama import OllamaLLM, Tool
 
 
 class TestOllamaLLM:
     """Test Ollama LLM integration."""
-    
+
     def test_tool_creation(self):
         """Test that tools are created correctly."""
         mock_api = Mock()
         llm = OllamaLLM(mock_api)
-        
+
         # Check that tools are created
         assert len(llm.tools) > 0
-        
+
         # Check that all tools have required attributes
         for tool in llm.tools:
             assert isinstance(tool, Tool)
@@ -25,103 +25,97 @@ class TestOllamaLLM:
             assert tool.description
             assert tool.parameters
             assert callable(tool.function)
-    
+
     def test_get_tool_by_name(self):
         """Test getting a tool by name."""
         mock_api = Mock()
         llm = OllamaLLM(mock_api)
-        
+
         # Test getting an existing tool
         tool = llm._get_tool_by_name("search_contacts")
         assert tool is not None
         assert tool.name == "search_contacts"
-        
+
         # Test getting a non-existent tool
         tool = llm._get_tool_by_name("non_existent_tool")
         assert tool is None
-    
+
     def test_call_tool(self):
         """Test calling a tool."""
         mock_api = Mock()
         mock_api.search_contacts.return_value = [{"id": 1, "name": "Test Contact"}]
-        
+
         llm = OllamaLLM(mock_api)
-        
+
         # Test successful tool call
         result = llm._call_tool("search_contacts", {"query": "test"})
         assert result == [{"id": 1, "name": "Test Contact"}]
         mock_api.search_contacts.assert_called_once_with(query="test")
-        
+
         # Test tool not found
         result = llm._call_tool("non_existent_tool", {})
         assert "error" in result
         assert "not found" in result["error"]
-        
+
         # Test tool call with exception
         mock_api.search_contacts.side_effect = Exception("Test error")
         result = llm._call_tool("search_contacts", {"query": "test"})
         assert "error" in result
         assert "Test error" in result["error"]
-    
+
     def test_system_prompt_creation(self):
         """Test system prompt creation."""
         mock_api = Mock()
         llm = OllamaLLM(mock_api)
-        
+
         prompt = llm._create_system_prompt()
-        
+
         # Check that the prompt contains expected sections
         assert "Personal Relationship Toolkit" in prompt
         assert "AVAILABLE TOOLS:" in prompt
         assert "search_contacts" in prompt  # At least one tool should be mentioned
         assert "INSTRUCTIONS:" in prompt
-    
+
     def test_format_tool_calls(self):
         """Test formatting tools for Ollama API."""
         mock_api = Mock()
         llm = OllamaLLM(mock_api)
-        
+
         formatted_tools = llm._format_tool_calls()
-        
+
         # Check that tools are formatted correctly
         assert len(formatted_tools) == len(llm.tools)
-        
+
         for tool in formatted_tools:
             assert "name" in tool
             assert "description" in tool
             assert "parameters" in tool
-    
-    @patch('requests.post')
+
+    @patch("requests.post")
     def test_chat_without_tool_calls(self, mock_post):
         """Test chat without tool calls."""
         mock_api = Mock()
         llm = OllamaLLM(mock_api)
-        
+
         # Mock response without tool calls
         mock_response = Mock()
         mock_response.json.return_value = {
-            "choices": [
-                {
-                    "message": {
-                        "content": "Hello! How can I help you today?"
-                    }
-                }
-            ]
+            "choices": [{"message": {"content": "Hello! How can I help you today?"}}]
         }
         mock_post.return_value = mock_response
-        
+
         result = llm.chat("Hello")
-        
+
         assert result == "Hello! How can I help you today?"
         assert len(llm.conversation_history) == 2  # user + assistant
-    
-    @patch('requests.post')
+
+    @patch("requests.post")
     def test_chat_with_tool_calls(self, mock_post):
         """Test chat with tool calls."""
         mock_api = Mock()
         mock_api.search_contacts.return_value = [{"id": 1, "name": "John Doe"}]
         llm = OllamaLLM(mock_api)
-        
+
         # Mock first response with tool call
         mock_response1 = Mock()
         mock_response1.json.return_value = {
@@ -133,77 +127,88 @@ class TestOllamaLLM:
                             {
                                 "id": "call_1",
                                 "name": "search_contacts",
-                                "arguments": {"query": "John"}
+                                "arguments": {"query": "John"},
                             }
-                        ]
+                        ],
                     }
                 }
             ]
         }
-        
+
         # Mock second response (after tool call)
         mock_response2 = Mock()
         mock_response2.json.return_value = {
-            "choices": [
-                {
-                    "message": {
-                        "content": "I found 1 contact: John Doe"
-                    }
-                }
-            ]
+            "choices": [{"message": {"content": "I found 1 contact: John Doe"}}]
         }
-        
+
         mock_post.side_effect = [mock_response1, mock_response2]
-        
+
         result = llm.chat("Find contacts named John")
-        
+
         # The result should contain the final response content
         assert "John Doe" in result or "Error" in result
         assert mock_post.call_count == 2  # Two API calls (tool call + final response)
-    
-    @patch('requests.post')
+
+    @patch("requests.post")
     def test_chat_connection_error(self, mock_post):
         """Test chat with connection error."""
         mock_api = Mock()
         llm = OllamaLLM(mock_api)
-        
+
         # Mock connection error
         mock_post.side_effect = Exception("Connection failed")
-        
+
         result = llm.chat("Hello")
-        
+
         assert "Error" in result
         assert "Connection failed" in result
-    
+
     def test_clear_history(self):
         """Test clearing conversation history."""
         mock_api = Mock()
         llm = OllamaLLM(mock_api)
-        
+
         # Add some history
         llm.conversation_history = [{"role": "user", "content": "test"}]
-        
+
         # Clear history
         llm.clear_history()
-        
+
         assert len(llm.conversation_history) == 0
+
+    def test_llm_registers_sql_and_backup_tools(self):
+        """Ensure execute_sql and backup tools are available."""
+        mock_api = Mock()
+        llm = OllamaLLM(mock_api)
+        tool_names = [t.name for t in llm.tools]
+        assert "execute_sql" in tool_names
+        assert "create_backup_with_comment" in tool_names
+
+    def test_system_prompt_mentions_sql_safety(self):
+        """System prompt should warn about SQL write safety."""
+        mock_api = Mock()
+        llm = OllamaLLM(mock_api)
+        prompt = llm._create_system_prompt()
+        assert "execute_sql" in prompt
+        assert "backup" in prompt.lower()
 
 
 class TestTool:
     """Test Tool dataclass."""
-    
+
     def test_tool_creation(self):
         """Test Tool dataclass creation."""
+
         def test_function():
             pass
-        
+
         tool = Tool(
             name="test_tool",
             description="A test tool",
             parameters={"type": "object"},
-            function=test_function
+            function=test_function,
         )
-        
+
         assert tool.name == "test_tool"
         assert tool.description == "A test tool"
         assert tool.parameters == {"type": "object"}


### PR DESCRIPTION
## Summary
- implement `execute_sql` API with write detection, confirmation, and automatic backup
- expose `execute_sql` and `create_backup_with_comment` as Ollama tools and warn about SQL safety in system prompt
- add tests covering SQL execution safety and tool registration

## Testing
- `pre-commit run --files prt_src/api.py prt_src/llm_ollama.py tests/test_ollama_integration.py tests/test_execute_sql.py`
- `pytest tests/test_execute_sql.py tests/test_ollama_integration.py::TestOllamaLLM::test_llm_registers_sql_and_backup_tools tests/test_ollama_integration.py::TestOllamaLLM::test_system_prompt_mentions_sql_safety -q`


------
https://chatgpt.com/codex/tasks/task_e_68b41b0446e8832fa7c7a3fc1345ac19