### PR TITLE
Add promptfoo evaluation tests

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ pre-commit
 ruff
 black
 
+promptfoo

--- a/tests/evals/echo_basic.yaml
+++ b/tests/evals/echo_basic.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+providers:
+  - echo
+
+prompts:
+  - 'Repeat: {{text}}'
+
+tests:
+  - vars:
+      text: 'hello world'
+    assert:
+      - type: icontains
+        value: 'hello world'

--- a/tests/promptfoo_runner.py
+++ b/tests/promptfoo_runner.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+COMMANDS = [
+    ["promptfoo", "eval"],
+    ["npx", "-y", "promptfoo", "eval"],
+]
+
+
+def run_promptfoo_scenario(path: Path) -> dict:
+    """Run a promptfoo evaluation scenario and return JSON results."""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
+        output_path = Path(tmp.name)
+
+    try:
+        for base in COMMANDS:
+            try:
+                subprocess.run(base + ["-c", str(path), "-o", str(output_path)], check=True)
+                break
+            except (subprocess.CalledProcessError, FileNotFoundError):
+                continue
+        else:
+            raise RuntimeError("promptfoo CLI is not available")
+
+        with output_path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    finally:
+        if output_path.exists():
+            output_path.unlink()

--- a/tests/test_promptfoo.py
+++ b/tests/test_promptfoo.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+
+from promptfoo_runner import run_promptfoo_scenario
+
+EVAL_PATH = Path(__file__).parent / "evals" / "echo_basic.yaml"
+
+
+def test_promptfoo_runs_scenarios():
+    result = run_promptfoo_scenario(EVAL_PATH)
+    assert isinstance(result, dict)
+    # ensure some results are present
+    assert result
+
+
+def test_promptfoo_output_contains_scores():
+    result = run_promptfoo_scenario(EVAL_PATH)
+    serialized = json.dumps(result).lower()
+    assert "score" in serialized


### PR DESCRIPTION
## Summary
- add `promptfoo` to dev dependencies
- add `run_promptfoo_scenario` helper and evaluation config
- test promptfoo scenario execution and score output

## Testing
- `pytest tests/test_promptfoo.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_68b41b05c2d4832fbc4418edeb2b7553