### PR TITLE
Add relationship type fixtures and update phase 3 tests

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -8,14 +8,17 @@ and profile images.
 
 import base64
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict
+
 
 def _generate_profile_images():
     """Generate realistic 256x256 JPEG profile images for test fixtures."""
     try:
         import sys
+
         sys.path.insert(0, str(Path(__file__).parent.parent))
         from utils.generate_profile_images import generate_profile_images
+
         return generate_profile_images()
     except ImportError:
         # Fallback to simple base64 images if Pillow is not available
@@ -23,9 +26,10 @@ def _generate_profile_images():
             "john_doe.jpg": {
                 "data": "/9j/4AAQSkZJRgABAQEAAQABAAD/2wBDAAEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/2wBDAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQH/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAv/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFQEBAQAAAAAAAAAAAAAAAAAAAAX/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIRAxEAPwA/8A8A",
                 "mime_type": "image/jpeg",
-                "filename": "john_doe.jpg"
+                "filename": "john_doe.jpg",
             }
         }
+
 
 # Generate realistic 256x256 JPEG profile images
 SAMPLE_IMAGES = _generate_profile_images()
@@ -36,78 +40,78 @@ SAMPLE_CONTACTS = [
         "name": "John Doe",
         "email": "john.doe@example.com",
         "phone": "+1-555-0101",
-        "image_key": "john_doe.jpg"
+        "image_key": "john_doe.jpg",
     },
     {
-        "name": "Jane Smith", 
+        "name": "Jane Smith",
         "email": "jane.smith@email.com",
         "phone": "+1-555-0102",
-        "image_key": "jane_smith.jpg"
+        "image_key": "jane_smith.jpg",
     },
     {
         "name": "Bob Wilson",
-        "email": "bob@work.com", 
+        "email": "bob@work.com",
         "phone": "+1-555-0103",
-        "image_key": "bob_wilson.jpg"
+        "image_key": "bob_wilson.jpg",
     },
     {
         "name": "Alice Johnson",
         "email": "alice.johnson@gmail.com",
         "phone": "+1-555-0104",
-        "image_key": "alice_johnson.jpg"
+        "image_key": "alice_johnson.jpg",
     },
     {
         "name": "Charlie Brown",
         "email": "charlie@company.org",
-        "phone": "+1-555-0105", 
-        "image_key": "charlie_brown.jpg"
+        "phone": "+1-555-0105",
+        "image_key": "charlie_brown.jpg",
     },
     {
         "name": "Diana Prince",
         "email": "diana.prince@hero.com",
         "phone": "+1-555-0106",
-        "image_key": "diana_prince.jpg"
-    }
+        "image_key": "diana_prince.jpg",
+    },
 ]
 
 # Sample tags
 SAMPLE_TAGS = [
     "family",
-    "friend", 
+    "friend",
     "colleague",
     "client",
     "neighbor",
     "classmate",
     "mentor",
-    "business_contact"
+    "business_contact",
 ]
 
-# Sample notes 
+# Sample notes
 SAMPLE_NOTES = [
     {
         "title": "First Meeting",
-        "content": "Met at the coffee shop downtown. Really nice person, we talked about work and hobbies."
+        "content": "Met at the coffee shop downtown. Really nice person, we talked about work and hobbies.",
     },
     {
-        "title": "Birthday Reminder", 
-        "content": "Birthday is in March. Likes chocolate cake and outdoor activities."
+        "title": "Birthday Reminder",
+        "content": "Birthday is in March. Likes chocolate cake and outdoor activities.",
     },
     {
         "title": "Project Discussion",
-        "content": "Discussed the new project timeline. Need to follow up next week about deliverables."
+        "content": "Discussed the new project timeline. Need to follow up next week about deliverables.",
     },
     {
         "title": "Personal Note",
-        "content": "Has two kids and a dog. Lives in the suburbs. Enjoys hiking on weekends."
+        "content": "Has two kids and a dog. Lives in the suburbs. Enjoys hiking on weekends.",
     },
     {
         "title": "Work Contact",
-        "content": "Works in marketing department. Good contact for future collaborations."
+        "content": "Works in marketing department. Good contact for future collaborations.",
     },
     {
         "title": "Emergency Contact",
-        "content": "Can be reached at work number during business hours. Backup emergency contact."
-    }
+        "content": "Can be reached at work number during business hours. Backup emergency contact.",
+    },
 ]
 
 # Relationships between contacts and tags/notes
@@ -115,64 +119,95 @@ SAMPLE_RELATIONSHIPS = [
     {
         "contact_name": "John Doe",
         "tags": ["friend", "colleague"],
-        "notes": ["First Meeting", "Personal Note"]
+        "notes": ["First Meeting", "Personal Note"],
     },
     {
-        "contact_name": "Jane Smith", 
+        "contact_name": "Jane Smith",
         "tags": ["family", "friend"],
-        "notes": ["Birthday Reminder", "Personal Note"]
+        "notes": ["Birthday Reminder", "Personal Note"],
     },
     {
         "contact_name": "Bob Wilson",
-        "tags": ["colleague", "business_contact"], 
-        "notes": ["Project Discussion", "Work Contact"]
+        "tags": ["colleague", "business_contact"],
+        "notes": ["Project Discussion", "Work Contact"],
     },
     {
         "contact_name": "Alice Johnson",
         "tags": ["friend", "neighbor"],
-        "notes": ["First Meeting", "Emergency Contact"]
+        "notes": ["First Meeting", "Emergency Contact"],
     },
     {
         "contact_name": "Charlie Brown",
         "tags": ["client", "business_contact"],
-        "notes": ["Project Discussion", "Work Contact"] 
+        "notes": ["Project Discussion", "Work Contact"],
     },
     {
         "contact_name": "Diana Prince",
         "tags": ["mentor", "colleague"],
-        "notes": ["Work Contact", "Personal Note"]
-    }
+        "notes": ["Work Contact", "Personal Note"],
+    },
+]
+
+# Contact-to-contact relationship types
+SAMPLE_RELATIONSHIP_TYPES = [
+    {
+        "type_key": "mother",
+        "description": "Is the mother of",
+        "inverse_type_key": None,
+        "is_symmetrical": 0,
+    },
+    {
+        "type_key": "coworker",
+        "description": "Is a coworker of",
+        "inverse_type_key": "coworker",
+        "is_symmetrical": 1,
+    },
+    {
+        "type_key": "friend",
+        "description": "Is a friend of",
+        "inverse_type_key": "friend",
+        "is_symmetrical": 1,
+    },
+]
+
+# Sample contact-to-contact relationships
+SAMPLE_CONTACT_RELATIONSHIPS = [
+    {"from": "Jane Smith", "to": "John Doe", "type": "mother"},
+    {"from": "Bob Wilson", "to": "Alice Johnson", "type": "coworker"},
+    {"from": "Alice Johnson", "to": "Bob Wilson", "type": "coworker"},
+    {"from": "John Doe", "to": "Charlie Brown", "type": "friend"},
+    {"from": "Charlie Brown", "to": "John Doe", "type": "friend"},
 ]
 
 
 def create_sample_contacts(db):
     """Create sample contacts in the database."""
     from prt_src.models import Contact
-    
+
     contacts = {}
     for contact_data in SAMPLE_CONTACTS:
         # Handle profile image
         profile_image = None
         profile_image_filename = None
         profile_image_mime_type = None
-        
+
         if contact_data.get("image_key") and contact_data["image_key"] in SAMPLE_IMAGES:
             image_info = SAMPLE_IMAGES[contact_data["image_key"]]
             profile_image = base64.b64decode(image_info["data"])
             profile_image_filename = image_info["filename"]
             profile_image_mime_type = image_info["mime_type"]
-        
+
         contact = Contact(
             name=contact_data["name"],
-            email=contact_data["email"], 
+            email=contact_data["email"],
             phone=contact_data["phone"],
             profile_image=profile_image,
             profile_image_filename=profile_image_filename,
-            profile_image_mime_type=profile_image_mime_type
+            profile_image_mime_type=profile_image_mime_type,
         )
         db.session.add(contact)
         contacts[contact_data["name"]] = contact
-    
+
     db.session.flush()  # Get IDs
     return contacts
 
@@ -180,13 +215,13 @@ def create_sample_contacts(db):
 def create_sample_tags(db):
     """Create sample tags in the database."""
     from prt_src.models import Tag
-    
+
     tags = {}
     for tag_name in SAMPLE_TAGS:
         tag = Tag(name=tag_name)
         db.session.add(tag)
         tags[tag_name] = tag
-    
+
     db.session.flush()  # Get IDs
     return tags
 
@@ -194,16 +229,13 @@ def create_sample_tags(db):
 def create_sample_notes(db):
     """Create sample notes in the database."""
     from prt_src.models import Note
-    
+
     notes = {}
     for note_data in SAMPLE_NOTES:
-        note = Note(
-            title=note_data["title"],
-            content=note_data["content"]
-        )
+        note = Note(title=note_data["title"], content=note_data["content"])
         db.session.add(note)
         notes[note_data["title"]] = note
-    
+
     db.session.flush()  # Get IDs
     return notes
 
@@ -211,55 +243,100 @@ def create_sample_notes(db):
 def create_sample_relationships(db, contacts, tags, notes):
     """Create sample relationships between contacts, tags, and notes."""
     from prt_src.models import Relationship
-    
+
     relationships = {}
-    
+
     # First create relationships for each contact
     for contact_name, contact in contacts.items():
         relationship = Relationship(contact_id=contact.id)
         db.session.add(relationship)
         relationships[contact_name] = relationship
-    
+
     db.session.flush()  # Get relationship IDs
-    
+
     # Now add tags and notes to relationships
     for rel_data in SAMPLE_RELATIONSHIPS:
         contact_name = rel_data["contact_name"]
         if contact_name in relationships:
             relationship = relationships[contact_name]
-            
+
             # Add tags
             for tag_name in rel_data.get("tags", []):
                 if tag_name in tags:
                     relationship.tags.append(tags[tag_name])
-            
-            # Add notes  
+
+            # Add notes
             for note_title in rel_data.get("notes", []):
                 if note_title in notes:
                     relationship.notes.append(notes[note_title])
-    
+
     return relationships
+
+
+def create_sample_relationship_types(db):
+    """Create sample relationship types."""
+    from prt_src.models import RelationshipType
+
+    rel_types = {}
+    for rt in SAMPLE_RELATIONSHIP_TYPES:
+        rel_type = RelationshipType(
+            type_key=rt["type_key"],
+            description=rt["description"],
+            inverse_type_key=rt["inverse_type_key"],
+            is_symmetrical=rt["is_symmetrical"],
+        )
+        db.session.add(rel_type)
+        rel_types[rt["type_key"]] = rel_type
+
+    db.session.flush()  # Get IDs
+    return rel_types
+
+
+def create_sample_contact_relationships(db, contacts, relationship_types):
+    """Create sample contact-to-contact relationships."""
+    from prt_src.models import ContactRelationship
+
+    rels = []
+    for rel in SAMPLE_CONTACT_RELATIONSHIPS:
+        from_contact = contacts.get(rel["from"])
+        to_contact = contacts.get(rel["to"])
+        rel_type = relationship_types.get(rel["type"])
+        if from_contact and to_contact and rel_type:
+            relationship = ContactRelationship(
+                from_contact=from_contact,
+                to_contact=to_contact,
+                relationship_type=rel_type,
+            )
+            db.session.add(relationship)
+            rels.append(relationship)
+
+    db.session.flush()  # Get IDs
+    return rels
 
 
 def setup_test_database(db):
     """Set up a complete test database with sample data."""
     # Initialize schema
     db.initialize()
-    
+
     # Create sample data
     contacts = create_sample_contacts(db)
     tags = create_sample_tags(db)
     notes = create_sample_notes(db)
     relationships = create_sample_relationships(db, contacts, tags, notes)
-    
+    relationship_types = create_sample_relationship_types(db)
+    contact_relationships = create_sample_contact_relationships(db, contacts, relationship_types)
+
     # Commit all changes
     db.session.commit()
-    
+
     return {
         "contacts": contacts,
-        "tags": tags, 
+        "tags": tags,
         "notes": notes,
-        "relationships": relationships
+        "relationships": relationships,
+        "relationship_types": relationship_types,
+        "contact_relationships": contact_relationships,
     }
 
 
@@ -270,7 +347,7 @@ def get_sample_image_data(image_key: str) -> Dict[str, Any]:
         return {
             "data": base64.b64decode(image_info["data"]),
             "filename": image_info["filename"],
-            "mime_type": image_info["mime_type"]
+            "mime_type": image_info["mime_type"],
         }
     return None
 
@@ -281,19 +358,19 @@ def print_database_summary(db):
     print("=" * 40)
     print(f"Contacts: {db.count_contacts()}")
     print(f"Relationships: {db.count_relationships()}")
-    
+
     # List contacts
     contacts = db.list_contacts()
     print(f"\nContacts ({len(contacts)}):")
     for contact_id, name, email in contacts:
         print(f"  {contact_id}: {name} ({email})")
-    
+
     # List tags
     tags = db.list_tags()
     print(f"\nTags ({len(tags)}):")
     for tag_id, name in tags:
         print(f"  {tag_id}: {name}")
-    
+
     # List notes
     notes = db.list_notes()
     print(f"\nNotes ({len(notes)}):")
@@ -306,28 +383,28 @@ if __name__ == "__main__":
     """Script to set up test database with sample data."""
     import sys
     from pathlib import Path
-    
+
     # Add project root to path
     sys.path.insert(0, str(Path(__file__).parent.parent))
-    
-    from prt_src.db import create_database
+
     from prt_src.config import data_dir
-    
+    from prt_src.db import create_database
+
     # Create test database
     test_db_path = data_dir() / "test_fixtures.db"
     print(f"Creating test database at: {test_db_path}")
-    
+
     # Remove existing test database
     if test_db_path.exists():
         test_db_path.unlink()
-    
+
     # Create and setup database
     db = create_database(test_db_path)
     fixtures = setup_test_database(db)
-    
-    print(f"✅ Test database created successfully!")
+
+    print("✅ Test database created successfully!")
     print_database_summary(db)
-    
-    print(f"\nTo use this database in tests:")
+
+    print("\nTo use this database in tests:")
     print(f"  db = create_database(Path('{test_db_path}'))")
-    print(f"  # Database already has sample data loaded")
+    print("  # Database already has sample data loaded")

--- a/tests/test_relationship_cli.py
+++ b/tests/test_relationship_cli.py
@@ -30,16 +30,16 @@ def mock_api():
     api.db.list_relationship_types.return_value = [
         {
             "id": 1,
-            "type_key": "parent_of",
-            "description": "Is the parent of",
-            "inverse_type_key": "child_of",
+            "type_key": "mother",
+            "description": "Is the mother of",
+            "inverse_type_key": None,
             "is_symmetrical": False,
         },
         {
             "id": 2,
-            "type_key": "friend_of",
+            "type_key": "friend",
             "description": "Is a friend of",
-            "inverse_type_key": "friend_of",
+            "inverse_type_key": "friend",
             "is_symmetrical": True,
         },
         {
@@ -55,8 +55,8 @@ def mock_api():
     api.db.get_contact_relationships.return_value = [
         {
             "relationship_id": 1,
-            "type": "parent_of",
-            "description": "Is the parent of",
+            "type": "mother",
+            "description": "Is the mother of",
             "other_contact_id": 2,
             "other_contact_name": "Bob Jones",
             "other_contact_email": "bob@example.com",
@@ -66,7 +66,7 @@ def mock_api():
         },
         {
             "relationship_id": 2,
-            "type": "friend_of",
+            "type": "friend",
             "description": "Is a friend of",
             "other_contact_id": 3,
             "other_contact_name": "Charlie Brown",
@@ -152,7 +152,7 @@ class TestAddRelationship:
             with patch("prt_src.cli.Prompt.ask") as mock_prompt:
                 with patch("prt_src.cli.Confirm.ask", return_value=True):
                     mock_prompt.side_effect = [
-                        "parent_of",  # relationship type
+                        "mother",  # relationship type
                         "",  # search for first contact (empty to see all)
                         "1",  # from contact ID
                         "",  # search for second contact (empty to see all)
@@ -164,7 +164,7 @@ class TestAddRelationship:
 
                     # Verify relationship was created
                     mock_api.db.create_contact_relationship.assert_called_once_with(
-                        1, 2, "parent_of", start_date=None
+                        1, 2, "mother", start_date=None
                     )
 
                     # Verify success message
@@ -175,7 +175,7 @@ class TestAddRelationship:
         with patch("prt_src.cli.console", mock_console):
             with patch("prt_src.cli.Prompt.ask") as mock_prompt:
                 mock_prompt.side_effect = [
-                    "friend_of",  # relationship type
+                    "friend",  # relationship type
                     "",  # search for first contact (empty to see all)
                     "1",  # from contact ID
                     "",  # search for second contact (empty to see all)
@@ -199,7 +199,7 @@ class TestAddRelationship:
         ]
 
         with patch("prt_src.cli.console", mock_console):
-            with patch("prt_src.cli.Prompt.ask", return_value="friend_of"):
+            with patch("prt_src.cli.Prompt.ask", return_value="friend"):
                 handle_add_relationship(mock_api)
 
                 # Should show error message
@@ -273,9 +273,7 @@ class TestDeleteRelationship:
                     handle_delete_relationship(mock_api)
 
                     # Verify deletion
-                    mock_api.db.delete_contact_relationship.assert_called_once_with(
-                        1, 2, "parent_of"
-                    )
+                    mock_api.db.delete_contact_relationship.assert_called_once_with(1, 2, "mother")
 
                     # Verify success message
                     mock_console.print.assert_any_call(
@@ -346,7 +344,7 @@ class TestRelationshipsMenu:
                 # Need more mock values for the add relationship flow
                 mock_prompt.side_effect = [
                     "2",  # select add from menu
-                    "friend_of",  # select relationship type
+                    "friend",  # select relationship type
                     "",  # search for first contact (empty to see all)
                     "1",  # first contact
                     "",  # search for second contact (empty to see all)
@@ -402,9 +400,9 @@ class TestRelationshipDisplayFormatting:
         """Test displaying symmetrical relationships."""
         mock_api.db.list_relationship_types.return_value = [
             {
-                "type_key": "friend_of",
+                "type_key": "friend",
                 "description": "Is a friend of",
-                "inverse_type_key": "friend_of",
+                "inverse_type_key": "friend",
                 "is_symmetrical": True,
             }
         ]
@@ -412,7 +410,7 @@ class TestRelationshipDisplayFormatting:
         with patch("prt_src.cli.console", mock_console):
             with patch("prt_src.cli.Prompt.ask") as mock_prompt:
                 mock_prompt.side_effect = [
-                    "friend_of",  # relationship type
+                    "friend",  # relationship type
                     "",  # search for first contact (empty to see all)
                     "1",  # first contact
                     "",  # search for second contact (empty to see all)

--- a/tests/test_relationships.py
+++ b/tests/test_relationships.py
@@ -6,20 +6,50 @@ including contact-to-contact relationships, relationship types with inverses,
 and backward compatibility with the renamed ContactMetadata model.
 """
 
-import pytest
 from datetime import date
+
+import pytest
 from sqlalchemy.exc import IntegrityError
+
 from prt_src.models import (
-    Contact, RelationshipType, ContactRelationship, 
-    ContactMetadata, Tag, Note, Relationship  # Test backward compat alias
+    Contact,
+    ContactMetadata,  # Test backward compat alias
+    ContactRelationship,
+    Note,
+    Relationship,
+    RelationshipType,
+    Tag,
 )
+
+
+def test_sample_contact_relationships_loaded(test_db):
+    """Verify sample contact relationships are created."""
+    db, fixtures = test_db
+
+    assert {"mother", "coworker", "friend"}.issubset(set(fixtures["relationship_types"].keys()))
+
+    rels = fixtures["contact_relationships"]
+
+    def has_rel(frm, to, type_key):
+        return any(
+            r.from_contact.name == frm
+            and r.to_contact.name == to
+            and r.relationship_type.type_key == type_key
+            for r in rels
+        )
+
+    assert has_rel("Jane Smith", "John Doe", "mother")
+    assert has_rel("Bob Wilson", "Alice Johnson", "coworker")
+    assert has_rel("Alice Johnson", "Bob Wilson", "coworker")
+    assert has_rel("John Doe", "Charlie Brown", "friend")
+    assert has_rel("Charlie Brown", "John Doe", "friend")
 
 
 @pytest.fixture
 def sample_contacts(test_db):
     """Create sample contacts for relationship testing."""
     db, _ = test_db
-    
+
     contacts = [
         Contact(name="John Doe", email="john@example.com"),
         Contact(name="Jane Doe", email="jane@example.com"),
@@ -28,13 +58,13 @@ def sample_contacts(test_db):
         Contact(name="Charlie Brown", email="charlie@example.com"),
         Contact(name="Diana Prince", email="diana@example.com"),
     ]
-    
+
     for contact in contacts:
         db.session.add(contact)
         # Add metadata for backward compatibility testing
         metadata = ContactMetadata(contact=contact)
         db.session.add(metadata)
-    
+
     db.session.commit()
     return contacts
 
@@ -43,58 +73,81 @@ def sample_contacts(test_db):
 def sample_relationship_types(test_db):
     """Create sample relationship types."""
     db, _ = test_db
-    
+
     types = [
         # Asymmetrical relationships
-        RelationshipType(type_key="parent_of", description="Is the parent of", 
-                        inverse_type_key="child_of", is_symmetrical=0),
-        RelationshipType(type_key="child_of", description="Is the child of", 
-                        inverse_type_key="parent_of", is_symmetrical=0),
-        RelationshipType(type_key="manages", description="Manages", 
-                        inverse_type_key="managed_by", is_symmetrical=0),
-        RelationshipType(type_key="managed_by", description="Is managed by", 
-                        inverse_type_key="manages", is_symmetrical=0),
-        
+        RelationshipType(
+            type_key="parent_of",
+            description="Is the parent of",
+            inverse_type_key="child_of",
+            is_symmetrical=0,
+        ),
+        RelationshipType(
+            type_key="child_of",
+            description="Is the child of",
+            inverse_type_key="parent_of",
+            is_symmetrical=0,
+        ),
+        RelationshipType(
+            type_key="manages",
+            description="Manages",
+            inverse_type_key="managed_by",
+            is_symmetrical=0,
+        ),
+        RelationshipType(
+            type_key="managed_by",
+            description="Is managed by",
+            inverse_type_key="manages",
+            is_symmetrical=0,
+        ),
         # Symmetrical relationships
-        RelationshipType(type_key="married_to", description="Is married to", 
-                        inverse_type_key="married_to", is_symmetrical=1),
-        RelationshipType(type_key="friend_of", description="Is a friend of", 
-                        inverse_type_key="friend_of", is_symmetrical=1),
+        RelationshipType(
+            type_key="married_to",
+            description="Is married to",
+            inverse_type_key="married_to",
+            is_symmetrical=1,
+        ),
+        RelationshipType(
+            type_key="friend_of",
+            description="Is a friend of",
+            inverse_type_key="friend_of",
+            is_symmetrical=1,
+        ),
     ]
-    
+
     for rel_type in types:
         db.session.add(rel_type)
-    
+
     db.session.commit()
     return types
 
 
 class TestRelationshipTypes:
     """Test relationship type functionality."""
-    
+
     def test_create_relationship_type_with_inverse(self, test_db):
         """Test creating an asymmetrical relationship type with inverse."""
         db, _ = test_db
-        
+
         # Create parent_of relationship
         parent_type = RelationshipType(
             type_key="parent_of",
             description="Is the parent of",
             inverse_type_key="child_of",
-            is_symmetrical=0
+            is_symmetrical=0,
         )
         db.session.add(parent_type)
-        
+
         # Create child_of relationship
         child_type = RelationshipType(
             type_key="child_of",
             description="Is the child of",
             inverse_type_key="parent_of",
-            is_symmetrical=0
+            is_symmetrical=0,
         )
         db.session.add(child_type)
         db.session.commit()
-        
+
         # Verify relationships were created
         assert parent_type.id is not None
         assert child_type.id is not None
@@ -102,49 +155,49 @@ class TestRelationshipTypes:
         assert child_type.inverse_type_key == "parent_of"
         assert parent_type.is_symmetrical == 0
         assert child_type.is_symmetrical == 0
-    
+
     def test_symmetrical_relationship_creates_single_type(self, test_db):
         """Test that symmetrical relationships point to themselves."""
         db, _ = test_db
-        
+
         # Create spouse_of relationship
         spouse_type = RelationshipType(
             type_key="spouse_of",
             description="Is the spouse of",
             inverse_type_key="spouse_of",  # Points to itself
-            is_symmetrical=1
+            is_symmetrical=1,
         )
         db.session.add(spouse_type)
         db.session.commit()
-        
+
         assert spouse_type.inverse_type_key == "spouse_of"
         assert spouse_type.is_symmetrical == 1
-    
+
     def test_duplicate_relationship_type_rejected(self, test_db):
         """Test that duplicate type_keys are rejected."""
         db, _ = test_db
-        
+
         # Create first relationship
         rel1 = RelationshipType(type_key="friend_of", description="Friend")
         db.session.add(rel1)
         db.session.commit()
-        
+
         # Try to create duplicate
         rel2 = RelationshipType(type_key="friend_of", description="Another Friend")
         db.session.add(rel2)
-        
+
         with pytest.raises(IntegrityError):
             db.session.commit()
         db.session.rollback()
-    
+
     def test_relationship_type_validation(self, test_db):
         """Test that type_key is required."""
         db, _ = test_db
-        
+
         # Try to create without type_key
         rel = RelationshipType(description="Some relationship")
         db.session.add(rel)
-        
+
         with pytest.raises(IntegrityError):
             db.session.commit()
         db.session.rollback()
@@ -152,352 +205,424 @@ class TestRelationshipTypes:
 
 class TestContactRelationships:
     """Test contact relationship functionality."""
-    
-    def test_create_bidirectional_relationship(self, test_db, sample_contacts, sample_relationship_types):
+
+    def test_create_bidirectional_relationship(
+        self, test_db, sample_contacts, sample_relationship_types
+    ):
         """Test creating parent-child relationship creates both directions."""
         db, _ = test_db
-        
+
         john = sample_contacts[0]  # Parent
-        bob = sample_contacts[2]   # Child
-        
+        bob = sample_contacts[2]  # Child
+
         # Get parent_of type
         parent_type = db.session.query(RelationshipType).filter_by(type_key="parent_of").first()
-        
+
         # Create parent -> child relationship
-        rel = ContactRelationship(
-            from_contact=john,
-            to_contact=bob,
-            relationship_type=parent_type
-        )
+        rel = ContactRelationship(from_contact=john, to_contact=bob, relationship_type=parent_type)
         db.session.add(rel)
         db.session.commit()
-        
+
         # Check the relationship was created
         assert rel.id is not None
         assert rel.from_contact_id == john.id
         assert rel.to_contact_id == bob.id
         assert rel.type_id == parent_type.id
-        
+
         # API should handle creating inverse automatically in db.py
-    
-    def test_create_symmetrical_relationship_single_entry(self, test_db, sample_contacts, sample_relationship_types):
+
+    def test_create_symmetrical_relationship_single_entry(
+        self, test_db, sample_contacts, sample_relationship_types
+    ):
         """Test that symmetrical relationships only need one entry."""
         db, _ = test_db
-        
+
         john = sample_contacts[0]
         jane = sample_contacts[1]
-        
+
         # Get married_to type
         married_type = db.session.query(RelationshipType).filter_by(type_key="married_to").first()
-        
+
         # Create marriage relationship
         rel = ContactRelationship(
-            from_contact=john,
-            to_contact=jane,
-            relationship_type=married_type
+            from_contact=john, to_contact=jane, relationship_type=married_type
         )
         db.session.add(rel)
         db.session.commit()
-        
+
         # Only one entry needed for symmetrical relationship
         count = db.session.query(ContactRelationship).filter_by(type_id=married_type.id).count()
         assert count == 1
-    
-    def test_delete_relationship_removes_both_directions(self, test_db, sample_contacts, sample_relationship_types):
+
+    def test_delete_relationship_removes_both_directions(
+        self, test_db, sample_contacts, sample_relationship_types
+    ):
         """Test that deleting a relationship removes both directions."""
         db, _ = test_db
-        
+
         john = sample_contacts[0]
         bob = sample_contacts[2]
         parent_type = db.session.query(RelationshipType).filter_by(type_key="parent_of").first()
         child_type = db.session.query(RelationshipType).filter_by(type_key="child_of").first()
-        
+
         # Create relationships
         rel1 = ContactRelationship(from_contact=john, to_contact=bob, relationship_type=parent_type)
         rel2 = ContactRelationship(from_contact=bob, to_contact=john, relationship_type=child_type)
         db.session.add_all([rel1, rel2])
         db.session.commit()
-        
+
         # Delete one relationship
         db.session.delete(rel1)
         db.session.commit()
-        
+
         # Both should be handled by cascade or API logic
-        remaining = db.session.query(ContactRelationship).filter(
-            ((ContactRelationship.from_contact_id == john.id) & (ContactRelationship.to_contact_id == bob.id)) |
-            ((ContactRelationship.from_contact_id == bob.id) & (ContactRelationship.to_contact_id == john.id))
-        ).count()
-        
+        remaining = (
+            db.session.query(ContactRelationship)
+            .filter(
+                (
+                    (ContactRelationship.from_contact_id == john.id)
+                    & (ContactRelationship.to_contact_id == bob.id)
+                )
+                | (
+                    (ContactRelationship.from_contact_id == bob.id)
+                    & (ContactRelationship.to_contact_id == john.id)
+                )
+            )
+            .count()
+        )
+
         # Note: Full bidirectional deletion logic is in db.py
         assert remaining <= 1  # May have one remaining if cascade not set up
-    
-    def test_unique_relationship_constraint(self, test_db, sample_contacts, sample_relationship_types):
+
+    def test_unique_relationship_constraint(
+        self, test_db, sample_contacts, sample_relationship_types
+    ):
         """Test that duplicate relationships are prevented."""
         db, _ = test_db
-        
+
         john = sample_contacts[0]
         jane = sample_contacts[1]
         friend_type = db.session.query(RelationshipType).filter_by(type_key="friend_of").first()
-        
+
         # Create first relationship
-        rel1 = ContactRelationship(from_contact=john, to_contact=jane, relationship_type=friend_type)
+        rel1 = ContactRelationship(
+            from_contact=john, to_contact=jane, relationship_type=friend_type
+        )
         db.session.add(rel1)
         db.session.commit()
-        
+
         # Try to create duplicate
-        rel2 = ContactRelationship(from_contact=john, to_contact=jane, relationship_type=friend_type)
+        rel2 = ContactRelationship(
+            from_contact=john, to_contact=jane, relationship_type=friend_type
+        )
         db.session.add(rel2)
-        
+
         with pytest.raises(IntegrityError):
             db.session.commit()
         db.session.rollback()
-    
+
     def test_relationship_with_dates(self, test_db, sample_contacts, sample_relationship_types):
         """Test relationships with start and end dates."""
         db, _ = test_db
-        
+
         alice = sample_contacts[3]
         charlie = sample_contacts[4]
         manages_type = db.session.query(RelationshipType).filter_by(type_key="manages").first()
-        
+
         # Create employment relationship with dates
         rel = ContactRelationship(
             from_contact=alice,
             to_contact=charlie,
             relationship_type=manages_type,
             start_date=date(2020, 1, 1),
-            end_date=date(2023, 12, 31)
+            end_date=date(2023, 12, 31),
         )
         db.session.add(rel)
         db.session.commit()
-        
+
         assert rel.start_date == date(2020, 1, 1)
         assert rel.end_date == date(2023, 12, 31)
 
 
 class TestIntegration:
     """Integration tests for complex scenarios."""
-    
+
     def test_family_tree_generation(self, test_db, sample_contacts):
         """Test building a family tree structure."""
         db, _ = test_db
-        
+
         # Create relationship types
-        parent_type = RelationshipType(type_key="parent_of", description="Parent of", 
-                                      inverse_type_key="child_of", is_symmetrical=0)
-        child_type = RelationshipType(type_key="child_of", description="Child of",
-                                     inverse_type_key="parent_of", is_symmetrical=0)
-        sibling_type = RelationshipType(type_key="sibling_of", description="Sibling of",
-                                       inverse_type_key="sibling_of", is_symmetrical=1)
-        
+        parent_type = RelationshipType(
+            type_key="parent_of",
+            description="Parent of",
+            inverse_type_key="child_of",
+            is_symmetrical=0,
+        )
+        child_type = RelationshipType(
+            type_key="child_of",
+            description="Child of",
+            inverse_type_key="parent_of",
+            is_symmetrical=0,
+        )
+        sibling_type = RelationshipType(
+            type_key="sibling_of",
+            description="Sibling of",
+            inverse_type_key="sibling_of",
+            is_symmetrical=1,
+        )
+
         db.session.add_all([parent_type, child_type, sibling_type])
         db.session.commit()
-        
+
         # Build family: John and Jane are parents of Bob and Alice
         john, jane, bob, alice = sample_contacts[:4]
-        
+
         # Parent relationships
-        db.session.add(ContactRelationship(from_contact=john, to_contact=bob, relationship_type=parent_type))
-        db.session.add(ContactRelationship(from_contact=john, to_contact=alice, relationship_type=parent_type))
-        db.session.add(ContactRelationship(from_contact=jane, to_contact=bob, relationship_type=parent_type))
-        db.session.add(ContactRelationship(from_contact=jane, to_contact=alice, relationship_type=parent_type))
-        
+        db.session.add(
+            ContactRelationship(from_contact=john, to_contact=bob, relationship_type=parent_type)
+        )
+        db.session.add(
+            ContactRelationship(from_contact=john, to_contact=alice, relationship_type=parent_type)
+        )
+        db.session.add(
+            ContactRelationship(from_contact=jane, to_contact=bob, relationship_type=parent_type)
+        )
+        db.session.add(
+            ContactRelationship(from_contact=jane, to_contact=alice, relationship_type=parent_type)
+        )
+
         # Sibling relationship
-        db.session.add(ContactRelationship(from_contact=bob, to_contact=alice, relationship_type=sibling_type))
-        
+        db.session.add(
+            ContactRelationship(from_contact=bob, to_contact=alice, relationship_type=sibling_type)
+        )
+
         db.session.commit()
-        
+
         # Query family relationships for Bob
-        bob_relationships = db.session.query(ContactRelationship).filter(
-            (ContactRelationship.from_contact_id == bob.id) | 
-            (ContactRelationship.to_contact_id == bob.id)
-        ).all()
-        
+        bob_relationships = (
+            db.session.query(ContactRelationship)
+            .filter(
+                (ContactRelationship.from_contact_id == bob.id)
+                | (ContactRelationship.to_contact_id == bob.id)
+            )
+            .all()
+        )
+
         assert len(bob_relationships) >= 1  # At least sibling relationship
-    
+
     def test_relationship_graph_cycles(self, test_db, sample_contacts):
         """Test handling circular relationships."""
         db, _ = test_db
-        
+
         # Create friend_of type (symmetrical)
-        friend_type = RelationshipType(type_key="friend_of", description="Friend of",
-                                      inverse_type_key="friend_of", is_symmetrical=1)
+        friend_type = RelationshipType(
+            type_key="friend_of",
+            description="Friend of",
+            inverse_type_key="friend_of",
+            is_symmetrical=1,
+        )
         db.session.add(friend_type)
         db.session.commit()
-        
+
         # Create circular friendships: A -> B -> C -> A
         alice, bob, charlie = sample_contacts[3:6]
-        
-        db.session.add(ContactRelationship(from_contact=alice, to_contact=bob, relationship_type=friend_type))
-        db.session.add(ContactRelationship(from_contact=bob, to_contact=charlie, relationship_type=friend_type))
-        db.session.add(ContactRelationship(from_contact=charlie, to_contact=alice, relationship_type=friend_type))
+
+        db.session.add(
+            ContactRelationship(from_contact=alice, to_contact=bob, relationship_type=friend_type)
+        )
+        db.session.add(
+            ContactRelationship(from_contact=bob, to_contact=charlie, relationship_type=friend_type)
+        )
+        db.session.add(
+            ContactRelationship(
+                from_contact=charlie, to_contact=alice, relationship_type=friend_type
+            )
+        )
         db.session.commit()
-        
+
         # All should have friend relationships
         for contact in [alice, bob, charlie]:
-            rels = db.session.query(ContactRelationship).filter(
-                (ContactRelationship.from_contact_id == contact.id) |
-                (ContactRelationship.to_contact_id == contact.id)
-            ).count()
+            rels = (
+                db.session.query(ContactRelationship)
+                .filter(
+                    (ContactRelationship.from_contact_id == contact.id)
+                    | (ContactRelationship.to_contact_id == contact.id)
+                )
+                .count()
+            )
             assert rels > 0
-    
+
     def test_migration_preserves_tags_and_notes(self, test_db):
         """Test that the migration preserves existing tag and note relationships."""
         db, _ = test_db
-        
+
         # Create contact with metadata (using new name)
         contact = Contact(name="Test User", email="test@example.com")
         db.session.add(contact)
-        
+
         metadata = ContactMetadata(contact=contact)
         db.session.add(metadata)
-        
+
         # Add tags and notes
         tag = Tag(name="Important")
         note = Note(title="Test Note", content="Some content")
         db.session.add_all([tag, note])
         db.session.commit()
-        
+
         # Associate via metadata
         metadata.tags.append(tag)
         metadata.notes.append(note)
         db.session.commit()
-        
+
         # Verify associations persist
         assert len(metadata.tags) == 1
         assert len(metadata.notes) == 1
         assert metadata.tags[0].name == "Important"
         assert metadata.notes[0].title == "Test Note"
-    
+
     def test_backward_compatibility_aliases(self, test_db):
         """Test that Relationship alias still works for backward compatibility."""
         db, _ = test_db
-        
+
         # Test that Relationship is an alias for ContactMetadata
         assert Relationship == ContactMetadata
-        
+
         # Old code using Relationship should still work
         contact = Contact(name="Legacy User", email="legacy@example.com")
         db.session.add(contact)
-        
+
         # Using old class name
         rel = Relationship(contact=contact)
         db.session.add(rel)
         db.session.commit()
-        
+
         assert rel.id is not None
         assert rel.contact_id == contact.id
-    
+
     def test_complex_relationship_queries(self, test_db, sample_contacts):
         """Test complex queries across relationship tables."""
         db, _ = test_db
-        
+
         # Create various relationship types
-        friend = RelationshipType(type_key="friend", description="Friend", 
-                                 inverse_type_key="friend", is_symmetrical=1)
-        colleague = RelationshipType(type_key="colleague", description="Colleague",
-                                    inverse_type_key="colleague", is_symmetrical=1)
+        friend = RelationshipType(
+            type_key="friend", description="Friend", inverse_type_key="friend", is_symmetrical=1
+        )
+        colleague = RelationshipType(
+            type_key="colleague",
+            description="Colleague",
+            inverse_type_key="colleague",
+            is_symmetrical=1,
+        )
         db.session.add_all([friend, colleague])
         db.session.commit()
-        
+
         # Create mixed relationships
         for i in range(len(sample_contacts) - 1):
             rel_type = friend if i % 2 == 0 else colleague
-            db.session.add(ContactRelationship(
-                from_contact=sample_contacts[i],
-                to_contact=sample_contacts[i + 1],
-                relationship_type=rel_type
-            ))
+            db.session.add(
+                ContactRelationship(
+                    from_contact=sample_contacts[i],
+                    to_contact=sample_contacts[i + 1],
+                    relationship_type=rel_type,
+                )
+            )
         db.session.commit()
-        
+
         # Query for all friends
-        friend_rels = db.session.query(ContactRelationship).join(
-            RelationshipType
-        ).filter(
-            RelationshipType.type_key == "friend"
-        ).count()
-        
+        friend_rels = (
+            db.session.query(ContactRelationship)
+            .join(RelationshipType)
+            .filter(RelationshipType.type_key == "friend")
+            .count()
+        )
+
         assert friend_rels > 0
-        
-        # Query for all colleagues  
-        colleague_rels = db.session.query(ContactRelationship).join(
-            RelationshipType
-        ).filter(
-            RelationshipType.type_key == "colleague"
-        ).count()
-        
+
+        # Query for all colleagues
+        colleague_rels = (
+            db.session.query(ContactRelationship)
+            .join(RelationshipType)
+            .filter(RelationshipType.type_key == "colleague")
+            .count()
+        )
+
         assert colleague_rels > 0
-    
+
     def test_relationship_cascade_delete(self, test_db, sample_contacts):
         """Test that deleting a relationship type cascades properly."""
         db, _ = test_db
-        
+
         # Create temporary relationship type
         temp_type = RelationshipType(type_key="temp_rel", description="Temporary")
         db.session.add(temp_type)
         db.session.commit()
-        
+
         # Create relationships using this type
         rel = ContactRelationship(
             from_contact=sample_contacts[0],
             to_contact=sample_contacts[1],
-            relationship_type=temp_type
+            relationship_type=temp_type,
         )
         db.session.add(rel)
         db.session.commit()
-        
+
         rel_id = rel.id
-        
+
         # Delete the relationship type
         db.session.delete(temp_type)
         db.session.commit()
-        
+
         # Relationship should be cascade deleted
         remaining = db.session.query(ContactRelationship).filter_by(id=rel_id).first()
         assert remaining is None
-    
+
     def test_contact_relationship_counts(self, test_db, sample_contacts):
         """Test counting relationships per contact."""
         db, _ = test_db
-        
+
         # Create friend type
-        friend = RelationshipType(type_key="friend", description="Friend",
-                                inverse_type_key="friend", is_symmetrical=1)
+        friend = RelationshipType(
+            type_key="friend", description="Friend", inverse_type_key="friend", is_symmetrical=1
+        )
         db.session.add(friend)
         db.session.commit()
-        
+
         # Make first contact friends with everyone else
         popular_contact = sample_contacts[0]
         for other in sample_contacts[1:]:
-            db.session.add(ContactRelationship(
-                from_contact=popular_contact,
-                to_contact=other,
-                relationship_type=friend
-            ))
+            db.session.add(
+                ContactRelationship(
+                    from_contact=popular_contact, to_contact=other, relationship_type=friend
+                )
+            )
         db.session.commit()
-        
+
         # Count relationships for popular contact
-        count = db.session.query(ContactRelationship).filter(
-            (ContactRelationship.from_contact_id == popular_contact.id) |
-            (ContactRelationship.to_contact_id == popular_contact.id)
-        ).count()
-        
+        count = (
+            db.session.query(ContactRelationship)
+            .filter(
+                (ContactRelationship.from_contact_id == popular_contact.id)
+                | (ContactRelationship.to_contact_id == popular_contact.id)
+            )
+            .count()
+        )
+
         assert count == len(sample_contacts) - 1
-    
+
     def test_relationship_type_descriptions(self, test_db):
         """Test that relationship descriptions are properly stored and retrieved."""
         db, _ = test_db
-        
+
         # Create relationship with detailed description
         rel_type = RelationshipType(
             type_key="mentor",
             description="Acts as a professional mentor providing career guidance",
             inverse_type_key="mentee",
-            is_symmetrical=0
+            is_symmetrical=0,
         )
         db.session.add(rel_type)
         db.session.commit()
-        
+
         # Retrieve and verify
         retrieved = db.session.query(RelationshipType).filter_by(type_key="mentor").first()
         assert retrieved.description == "Acts as a professional mentor providing career guidance"


### PR DESCRIPTION
## Summary
- seed sample relationship types (mother, coworker, friend) and contact-to-contact links in test fixtures
- expose new relationship data from `setup_test_database`
- adjust Phase 3 evaluation tests to use these relationship fixtures

## Testing
- `pre-commit run --files tests/fixtures.py tests/test_core_operations.py tests/test_relationship_cli.py tests/test_relationships.py`
- `pytest tests/test_relationship_cli.py tests/test_core_operations.py tests/test_relationships.py::test_sample_contact_relationships_loaded`

------
https://chatgpt.com/codex/tasks/task_e_68b41b073a30832fb2e88ca7eb20b9fe