### PR TITLE
fix: Category 1 - Fix async mock service issues in tests

### DIFF
--- a/tests/test_import_export_integration.py
+++ b/tests/test_import_export_integration.py
@@ -1,5 +1,6 @@
 """Integration tests for import and export screens."""
 
+from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 import pytest
@@ -25,7 +26,7 @@ class TestImportExportIntegration:
         mock_services = {
             "nav_service": MagicMock(),
             "data_service": MagicMock(),
-            "notification_service": MagicMock(),
+            "notification_service": AsyncMock(),
             "selection_service": MagicMock(),
             "validation_service": MagicMock(),
         }
@@ -41,7 +42,7 @@ class TestImportExportIntegration:
         mock_services = {
             "nav_service": MagicMock(),
             "data_service": MagicMock(),
-            "notification_service": MagicMock(),
+            "notification_service": AsyncMock(),
             "selection_service": MagicMock(),
             "validation_service": MagicMock(),
         }
@@ -76,7 +77,7 @@ class TestImportExportIntegration:
         mock_app = MagicMock()
 
         home_screen = HomeScreen(
-            nav_service=mock_nav_service, data_service=MagicMock(), notification_service=MagicMock()
+            nav_service=mock_nav_service, data_service=AsyncMock(), notification_service=AsyncMock()
         )
         # Mock the app attribute for the async switch
         home_screen._app = mock_app

--- a/tests/test_phase4b_screens.py
+++ b/tests/test_phase4b_screens.py
@@ -3,6 +3,7 @@
 Tests all 7 screens implemented in Phase 4B.
 """
 
+from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
 from prt_src.tui.screens.base import EscapeIntent
@@ -24,7 +25,7 @@ def mock_services():
     nav_service.get_breadcrumb.return_value = ["Home", "Test"]
 
     data_service = MagicMock(spec=DataService)
-    notification_service = MagicMock(spec=NotificationService)
+    notification_service = AsyncMock(spec=NotificationService)
 
     return {
         "nav_service": nav_service,

--- a/tests/test_wizard_screen.py
+++ b/tests/test_wizard_screen.py
@@ -16,10 +16,19 @@ class TestWizardScreen:
     @pytest.fixture
     def mock_services(self):
         """Create mock services for testing."""
+        # Create AsyncMock for notification service since its methods are async
+        notification_mock = AsyncMock()
+        # Set up common async methods that return coroutines
+        notification_mock.show_error = AsyncMock()
+        notification_mock.show_success = AsyncMock()
+        notification_mock.show_warning = AsyncMock()
+        notification_mock.show_info = AsyncMock()
+        notification_mock.show_confirm_dialog = AsyncMock()
+        
         return {
             "nav_service": MagicMock(),
-            "data_service": MagicMock(),
-            "notification_service": MagicMock(),
+            "data_service": AsyncMock(),  # Also make data_service async since many methods are async
+            "notification_service": notification_mock,
         }
 
     @pytest.fixture


### PR DESCRIPTION
## 🎯 Category 1 Test Fixes: Async Mock Services

**Problem**: Tests using `MagicMock()` for async notification services caused `TypeError: object MagicMock can't be used in 'await' expression`

**Solution**: Replace `MagicMock` with `AsyncMock` for async services

## ✅ Tests Fixed (3 tests)

- `test_wizard_screen.py::test_create_you_contact_no_name` ✅
- `test_wizard_screen.py::test_handle_load_demo_failure` ✅ 
- `test_wizard_screen.py::test_handle_start_empty` ✅

## 🔧 Changes Made

### Enhanced Mock Fixtures
- **notification_service**: Now uses `AsyncMock()` with proper async methods
- **data_service**: Updated to `AsyncMock()` for async data operations  
- **Proper async patterns**: Tests can now properly `await` service calls

### Files Modified
- `tests/test_wizard_screen.py`: Enhanced mock_services fixture
- `tests/test_import_export_integration.py`: Fixed notification mocks
- `tests/test_phase4b_screens.py`: Fixed notification service mock

## 📊 Impact

**Before**: 565 tests passing, 14 failing  
**After**: 568 tests passing, 11 failing  
**Improvement**: +3 tests fixed, **98.1% pass rate**

## 🎯 Next Steps

Remaining test failure categories:
- Category 2: Textual property mocking (5 tests)
- Category 3: String expectations (1 test)  
- Category 4: Database isolation (2 tests)

This PR establishes proper async testing patterns for TUI services
