### PR TITLE
Adjust confirm dialog sizing

### DIFF
--- a/prt_src/tui/styles.tcss
+++ b/prt_src/tui/styles.tcss
@@ -622,8 +622,10 @@ Footer {
 }
 
 .confirm-content {
-    width: 50;
-    height: 10;
+    width: 90%;
+    max-width: 60;
+    min-width: 30;
+    max-height: 85%;
     background: $panel;
     border: thick $primary;
     padding: 2;


### PR DESCRIPTION
## Summary
- replace the confirmation dialog's fixed width and height with percentage-based sizing
- constrain the dialog with max/min widths and a max-height so it remains visible on small terminals

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68ca83d5a008832fb1ea6c21acb116f5