### PR TITLE
Adjust navigation menu height behavior

### DIFF
--- a/prt_src/tui/styles.tcss
+++ b/prt_src/tui/styles.tcss
@@ -331,7 +331,7 @@ Footer {
 /* Navigation Menu */
 .navigation-menu {
     width: 100%;
-    min-height: 20;
+    height: 1fr;
     max-height: 80%;
     padding: 1;
     overflow-y: auto;
@@ -339,7 +339,8 @@ Footer {
 
 .menu-container {
     width: 100%;
-    min-height: 20;
+    height: auto;
+    max-height: 100%;
     overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- allow the navigation menu to flex within its container instead of enforcing a 20-row minimum height
- ensure the menu container keeps overflow scrolling while shrinking with the terminal height

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca83d679bc832fb2316466db373914