### PR TITLE
Ensure TUI main container stretches to terminal size

### DIFF
--- a/prt_src/tui/app.py
+++ b/prt_src/tui/app.py
@@ -187,7 +187,11 @@ class PRTApp(App):
     def compose(self) -> ComposeResult:
         """Compose the application layout."""
         yield Header()
-        yield Container(Static("Welcome to PRT!", id="welcome"), id="main-container")
+        yield Container(
+            Static("Welcome to PRT!", id="welcome"),
+            id="main-container",
+            classes="main-container",
+        )
         yield Footer()
 
     def on_mount(self) -> None:
@@ -442,7 +446,13 @@ class PRTApp(App):
         # Only mount new screen with unique container ID if the main container approach failed
         if not mount_successful:
             self.current_container_id = f"main-container-{uuid.uuid4().hex[:8]}"
-            await self.mount(Container(new_screen, id=self.current_container_id))
+            await self.mount(
+                Container(
+                    new_screen,
+                    id=self.current_container_id,
+                    classes="main-container",
+                )
+            )
             logger.debug(f"Mounted screen in new container: {self.current_container_id}")
         else:
             # Keep using the main container

--- a/prt_src/tui/styles.tcss
+++ b/prt_src/tui/styles.tcss
@@ -17,7 +17,10 @@ Header.edit-mode {
 }
 
 /* Main container */
-#main-container {
+#main-container, .main-container {
+    width: 100%;
+    height: 1fr;
+    overflow: hidden auto;
     padding: 1;
 }
 


### PR DESCRIPTION
## Summary
- update the main container styling so both id and class selectors enforce full-width, flex-height layout with scroll overflow control
- apply the shared main-container class when composing the layout and when creating fallback containers during screen switches

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68ca83dafa14832f9deca193573d463b