### PR TITLE
Shared block v6: hub plan.md renamed to software-plan.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,16 +27,25 @@
 > Everything below this banner describes how the project worked while it was live. It is
 > accurate history, kept for the harvest — not an invitation to develop against it.
 
-<!-- BEGIN SHARED: org-conventions v4 -->
+<!-- BEGIN SHARED: org-conventions v6 -->
 <!-- Canonical copy: social-network-health/docs/shared/org-conventions.md
      Do not edit this block in place. Edit the canonical copy and propagate. -->
 
+> **⚙ Shared, generated section — don't edit it here.** Everything from this line down to
+> *"Changing this block"* is identical in every repo in the org. Change it in the canonical
+> copy (hub `docs/shared/org-conventions.md`) and run `just sync-conventions`; an edit made
+> in place will be reported as `EDITED` and then overwritten. Repo-specific guidance belongs
+> in this file's *other* sections, which the tooling never touches.
+
 ## The organization
 
-Eight repos under the **[social-network-health](https://github.com/social-network-health)**
-GitHub org. A developer normally has them **all checked out side by side in one parent
-directory**, so from any repo root every other repo is at `../<name>`. Write cross-repo paths
-relative to the repo root, never absolute — the parent directory differs per host.
+The repos of the **[social-network-health](https://github.com/social-network-health)** GitHub
+org. A developer normally has them **all checked out side by side in one parent directory**,
+so from any repo root every other repo is at `../<name>`. Write cross-repo paths relative to
+the repo root, never absolute — the parent directory differs per host.
+
+The set changes as repos are added and archived, so no document states a count; ask the org
+(`gh repo list social-network-health`) or read `RELATED_REPOS.md`.
 
 **[`RELATED_REPOS.md`](https://github.com/social-network-health/social-network-health/blob/main/RELATED_REPOS.md)**
 in the hub repo is the single source of truth for what those repos are and what each is for.
@@ -51,7 +60,7 @@ is the only channel that reaches every worktree and every concurrent agent.
 
 | # | Question | Lives in |
 |---|---|---|
-| 1 | "What is the software program?" | hub [`plan.md`](https://github.com/social-network-health/social-network-health/blob/main/plan.md) — the M1/M2/M3 summary |
+| 1 | "What is the software program?" | hub [`software-plan.md`](https://github.com/social-network-health/social-network-health/blob/main/software-plan.md) — the M1/M2/M3 summary |
 | 2 | "What should the org be doing?" | hub [`plans/`](https://github.com/social-network-health/social-network-health/tree/main/plans) + `plans/ORG-TASKS.md` |
 | 3 | "Where is this repo headed?" | **this repo's** `docs/roadmap.md` |
 | 4 | "What's in flight?" | **this repo's** GitHub issues and active branches |
@@ -60,7 +69,7 @@ Record a thought at the layer matching its scope.
 
 **Layer 2 is org-only.** Work actionable inside one existing repo belongs in that repo;
 `ORG-TASKS.md` links down to it rather than restating its status. **Layer 1 is narrower than
-the organization** — `plan.md` summarizes the software and research program, not community
+the organization** — `software-plan.md` summarizes the software and research program, not community
 building, the toolkit wiki, or educational materials.
 
 Dated files under `plans/` are append-only thinking artifacts. Never update one; write a new
@@ -92,7 +101,7 @@ Each of these was learned the hard way in one repo. They apply in all of them.
   worktree setup and port serialization live in that repo's own sections.
 - **A sync rule without a mechanical check is a wish.** Anything that must hold in more than
   one repo ships with a command that verifies it, and the rule names the command. Nobody
-  eyeballs eight repos, so silent drift is the default outcome otherwise.
+  eyeballs every repo by hand, so silent drift is the default outcome otherwise.
 - **Add a load-bearing document or module → update `.claude/commands/prime.md` in the same
   PR.** Priming is how every agent gets its systems-level picture of a repo, and a prime that
   misses the file where the invariants live sends every future session searching for it. This
@@ -111,7 +120,7 @@ markers, run `just sync-conventions` from the hub repo, then open one PR per rep
 `just check-conventions` verifies every copy matches; `just check-org` runs every org check.
 Full procedure: hub `docs/org-upkeep.md`.
 
-<!-- END SHARED: org-conventions v4 -->
+<!-- END SHARED: org-conventions v6 -->
 
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.


### PR DESCRIPTION
Shared block v6, generated by `just sync-conventions` from the canonical copy in the hub. Not hand-edited.

**One change:** the hub's `plan.md` was renamed to **`software-plan.md`**, and the block's planning-layers table links it. The old name invited reading it as the plan for everything the organization does, when it covers the software and research program only — community building, the toolkit wiki, and educational materials are deliberately outside it.

The link in this repo's `CLAUDE.md` would 404 once the hub rename merges, which is why this PR exists.

Canonical copy: [`social-network-health/docs/shared/org-conventions.md`](https://github.com/social-network-health/social-network-health/blob/main/docs/shared/org-conventions.md).

The hub PR also adds `just prs` (every open PR across the org, with links) and `just dashboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
