### PR TITLE
Shared block v7: brainstorms live in snh-private, via the snhb skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@
 > Everything below this banner describes how the project worked while it was live. It is
 > accurate history, kept for the harvest — not an invitation to develop against it.
 
-<!-- BEGIN SHARED: org-conventions v6 -->
+<!-- BEGIN SHARED: org-conventions v7 -->
 <!-- Canonical copy: social-network-health/docs/shared/org-conventions.md
      Do not edit this block in place. Edit the canonical copy and propagate. -->
 
@@ -112,6 +112,13 @@ Each of these was learned the hard way in one repo. They apply in all of them.
   it holds what is always true and stays short. Prime is opt-in and costs tokens, so it holds
   the *reading list* — which files give systems-level understanding, and which to skim rather
   than read. Keep prime curated: name the seams, never glob a directory.
+- **Brainstorms are private and live in `snh-private`, never in a public repo.** Use the
+  **`snhb`** skill: it captures to `../snh-private/brainstorms/<this repo>/`, checkpoints
+  after every answer, and commits at session end so the thinking follows you between
+  machines. It also *searches* every repo's brainstorms — ask it what you previously decided
+  about something rather than re-deriving it. They're private because unreviewed thinking
+  wastes the reader's time, not because it's secret; when one is worth publishing, review it
+  and put a **cleaned copy** in the public destination, leaving the original where it is.
 
 ## Changing this block
 
@@ -120,7 +127,7 @@ markers, run `just sync-conventions` from the hub repo, then open one PR per rep
 `just check-conventions` verifies every copy matches; `just check-org` runs every org check.
 Full procedure: hub `docs/org-upkeep.md`.
 
-<!-- END SHARED: org-conventions v6 -->
+<!-- END SHARED: org-conventions v7 -->
 
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.


### PR DESCRIPTION
Shared block v7, generated by `just sync-conventions`. Not hand-edited.

**One addition** — the org now has a private repo and a brainstorm skill, so every repo needs to know where brainstorms go:

> **Brainstorms are private and live in `snh-private`, never in a public repo.** Use the **`snhb`** skill: it captures to `../snh-private/brainstorms/<this repo>/`, checkpoints after every answer, and commits at session end so the thinking follows you between machines. It also *searches* every repo's brainstorms — ask it what you previously decided about something rather than re-deriving it. They're private because unreviewed thinking wastes the reader's time, not because it's secret; when one is worth publishing, review it and put a **cleaned copy** in the public destination, leaving the original where it is.

The problem it solves: brainstorms used to land in a gitignored folder on whichever machine you were using, so half lived on a laptop and half on a workstation with neither able to see the other's. This repo's own docs linked captures that existed on no checked-in machine.

`just bootstrap` clones `snh-private` and `just install-skills` symlinks `snhb`. Both need access to the private repo; without it `check-skills` reports `SOURCE MISSING`, which is the honest answer rather than a skill that fails at write time.

Canonical copy: [`social-network-health/docs/shared/org-conventions.md`](https://github.com/social-network-health/social-network-health/blob/main/docs/shared/org-conventions.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
